### PR TITLE
Feat : 테마 별 글 조회, 페이징 처리(무한 스크롤), 사용자 네이밍 변경

### DIFF
--- a/src/main/java/team/compass/chat/domain/ChattingRoomUser.java
+++ b/src/main/java/team/compass/chat/domain/ChattingRoomUser.java
@@ -1,6 +1,6 @@
 package team.compass.chat.domain;
 
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/team/compass/comment/domain/Comment.java
+++ b/src/main/java/team/compass/comment/domain/Comment.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 import team.compass.post.domain.Post;
 
 import javax.persistence.*;

--- a/src/main/java/team/compass/common/config/JwtTokenProvider.java
+++ b/src/main/java/team/compass/common/config/JwtTokenProvider.java
@@ -12,7 +12,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import team.compass.member.dto.TokenDto;
+import team.compass.user.dto.TokenDto;
 
 import java.security.Key;
 import java.util.Arrays;

--- a/src/main/java/team/compass/like/domain/Likes.java
+++ b/src/main/java/team/compass/like/domain/Likes.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 import team.compass.post.domain.Post;
 
 

--- a/src/main/java/team/compass/like/repository/LikeRepository.java
+++ b/src/main/java/team/compass/like/repository/LikeRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.stereotype.Repository;
 import team.compass.like.domain.Likes;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 import team.compass.post.domain.Post;
 
 

--- a/src/main/java/team/compass/like/service/LikeService.java
+++ b/src/main/java/team/compass/like/service/LikeService.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service;
 import team.compass.like.domain.Likes;
 import team.compass.like.dto.LikeDto;
 import team.compass.like.repository.LikeRepository;
-import team.compass.member.domain.User;
-import team.compass.member.repository.UserRepository;
+import team.compass.user.domain.User;
+import team.compass.user.repository.UserRepository;
 
 import team.compass.post.domain.Post;
 import team.compass.post.repository.PostRepository;

--- a/src/main/java/team/compass/photo/domain/Photo.java
+++ b/src/main/java/team/compass/photo/domain/Photo.java
@@ -17,7 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 import team.compass.post.domain.PostPhoto;
 
 @Entity

--- a/src/main/java/team/compass/photo/repository/PostPhotoRepository.java
+++ b/src/main/java/team/compass/photo/repository/PostPhotoRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 
 public interface PostPhotoRepository extends JpaRepository<PostPhoto, Integer> {
     @Query("select pp from PostPhoto pp left join pp.photo where pp.post.id = :id")
-    List<PostPhoto> findListById(@Param(value = "id") Integer id); // 단건 조회
+    List<PostPhoto> findListById(@Param(value = "id") Integer id); // 단건 조회 post <-> photo 연결
 }

--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -1,69 +1,57 @@
 package team.compass.post.controller;
 
-import java.util.List;
-
-
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-
-import io.swagger.annotations.ApiOperation;
-import team.compass.member.domain.User;
-import team.compass.member.repository.UserRepository;
 import team.compass.post.controller.request.PostRequest;
 import team.compass.post.controller.response.PostResponse;
 import team.compass.post.domain.Post;
 import team.compass.post.service.PostService;
+import team.compass.user.domain.User;
+import team.compass.user.repository.UserRepository;
+
+import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 public class PostController {
 
+    private final PostService postService;
 
-    @Autowired
-    private PostService postService;
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
-    @ApiOperation(value = "메인 페이지 select 입니다.", notes = "메인 페이지 select")
-    @GetMapping("/main")
+
+    @ApiOperation(value = "해당 테마 페이지 글들 select 입니다.", notes = "테마 페이지 select")
+    @GetMapping("/post")
     @Transactional(readOnly = true)
-    public ResponseEntity<Object> getMain() {
-        return postService.mainPageSelect();
+    public ResponseEntity<Object> getThemePage(
+            @RequestParam(required = false) Integer lastId, // required default 값이 true... 첫 상단에는 null이어야 하니 false 로 잡음
+            @RequestParam(defaultValue = "1") Integer themeId) {
+        // 아무데이터도 안들어왔을때
+        // 기본값으로 theme 1 로 들어감 last id = null
+        return  ResponseEntity.ok(postService.themePageSelect(themeId, lastId));
     }
 
     @ApiOperation(value = "글 쓰기 api 입니다.", notes = "글작성, 사진첨부까지 함께 저장합니다.")
     @PostMapping(value = "/post")
     @Transactional
     public ResponseEntity<Object> postWrite(
-            @RequestPart(value = "data") PostRequest post,
-            @RequestPart(value = "images") List<MultipartFile> images) {
+            @RequestPart(value = "data") PostRequest post, // request post 로 받아오기. 내용들
+            @RequestPart(value = "images") List<MultipartFile> images) { // 이미지 받아오기
 
-        validationPhoto(images);
+        validationPhoto(images); // 유효성 검증(이미지 최대 5개까지 받아올 수 있게)
         User user = userRepository.findById(1)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // 임시로 넣어둔 유저
 
-        Post postEntity = post.toEntity();
-        System.out.println("postEntity.getTheme().getId() = " + postEntity.getTheme().getId());
-        postEntity.setUser(user);
+        Post postEntity = post.toEntity(); // toEntity -> 넣어주기
+        postEntity.setUser(user); // toEntity 에 user 값 넣기
 
-        Post write = postService.write(postEntity, images, user);
+        Post write = postService.write(postEntity, images, user); // 받았던 글 post(글과 사진, 유저) write 에 담기
 
-        return ResponseEntity.ok("ok");
-    }
-
-    private static void validationPhoto(List<MultipartFile> images) {
-        if (images.size() > 5) {
-            throw new IllegalArgumentException("사진은 5장까지만 등록 가능합니다.");
-        }
+        return ResponseEntity.ok(write);
     }
 
     @ApiOperation(value = "글 수정 api 입니다.", notes = "글 수정, 사진 수정")
@@ -72,15 +60,15 @@ public class PostController {
     public ResponseEntity<Object> postUpdate(
             @RequestPart(value = "data") PostRequest post,
             @RequestPart(value = "images") List<MultipartFile> images,
-            @PathVariable Integer postId) {
+            @PathVariable Integer postId) { // 글 id 받기 위해
 
         validationPhoto(images);
         User user = userRepository.findById(1)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // user 체크
 
-        Post updatePost = postService.update(post.toEntity(), images, user, postId);
+        Post updatePost = postService.update(post.toEntity(), images, user, postId); // 업데이트 받아온 것 저장
 
-        return ResponseEntity.ok(new PostResponse(updatePost));
+        return ResponseEntity.ok(new PostResponse(updatePost)); // response 에 담아 보내기
     }
 
     @ApiOperation(value = "글 삭제 api 입니다.", notes = "해당 글을 삭제하면 연관되어 있는 해당 글, 사진, 좋아요, 댓글 삭제됩니다.")
@@ -101,5 +89,12 @@ public class PostController {
         return ResponseEntity.ok(new PostResponse(post));
     }
 
+
+    // 사진 5개 등록 제한걸어두기
+    private static void validationPhoto(List<MultipartFile> images) {
+        if (images.size() > 5) {
+            throw new IllegalArgumentException("사진은 5장까지만 등록 가능합니다.");
+        }
+    }
 }
 

--- a/src/main/java/team/compass/post/controller/request/PostRequest.java
+++ b/src/main/java/team/compass/post/controller/request/PostRequest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 public class PostRequest {
 
+
     private String title; // 제목
     private String detail; // 내용
     private String location;
@@ -23,7 +24,7 @@ public class PostRequest {
     private String hashtag; // 해시태그 (프론트에서 받아옴, #마다 잘라서 문자로 들어옴)
     private Integer themeId;
 
-    // DTO - ENTITY
+    // DTO - ENTITY (toEntity를 DTO 에서 해주는 것.) Entity 는 테이블 그 자체이기에 건들면 위험함
     public Post toEntity() {
         return Post.builder()
                 .title(title)

--- a/src/main/java/team/compass/post/domain/Post.java
+++ b/src/main/java/team/compass/post/domain/Post.java
@@ -26,7 +26,7 @@ import lombok.Setter;
 
 import team.compass.comment.domain.Comment;
 import team.compass.like.domain.Likes;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 import team.compass.theme.domain.Theme;
 
 @Entity
@@ -73,7 +73,7 @@ public class Post {
     @OneToMany(mappedBy = "post",fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<PostPhoto> photos; // 사진
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id")
     private Theme theme; // 테마
 

--- a/src/main/java/team/compass/post/dto/PhotoDto.java
+++ b/src/main/java/team/compass/post/dto/PhotoDto.java
@@ -3,7 +3,7 @@ package team.compass.post.dto;
 
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 import team.compass.photo.domain.Photo;
 import team.compass.photo.util.MultipartUtil;
 

--- a/src/main/java/team/compass/post/dto/PostDto.java
+++ b/src/main/java/team/compass/post/dto/PostDto.java
@@ -11,7 +11,7 @@ import lombok.Data;
 public class PostDto {
     private Integer postId;
     private Integer likeCount;
-    private List<String> photoName;
+    private List<String> storeFileUrl;
 
     private String title;
 
@@ -20,10 +20,10 @@ public class PostDto {
     private String startDate;
     private String endDate;
 
-    public PostDto(Integer postId, Integer likeCount, List<String> photoName, String title, String location, String startDate, String endDate) {
+    public PostDto(Integer postId, Integer likeCount, List<String> storeFileUrl, String title, String location, String startDate, String endDate) {
         this.postId = postId;
         this.likeCount = likeCount;
-        this.photoName = photoName;
+        this.storeFileUrl = storeFileUrl;
         this.title = title;
         this.location = location;
         this.startDate = startDate;

--- a/src/main/java/team/compass/post/repository/PostCustomRepository.java
+++ b/src/main/java/team/compass/post/repository/PostCustomRepository.java
@@ -1,0 +1,9 @@
+package team.compass.post.repository;
+
+import team.compass.post.domain.Post;
+
+import java.util.List;
+
+public interface PostCustomRepository  {
+    List<Post> findByTheme(Integer theme, Integer lastId);
+}

--- a/src/main/java/team/compass/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/team/compass/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,40 @@
+package team.compass.post.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.compass.post.domain.Post;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public List<Post> findByTheme(Integer theme, Integer lastId) {
+
+        String first = "select p from Post p  where p.theme.id =:theme order by p.id desc";
+
+        String paging = "select p from Post p where p.theme.id =:theme and p.id < :lastId order by p.id desc ";
+
+        TypedQuery<Post> query=null;
+
+        if (lastId == null) { // 만약 lastId 가 null 일 경우
+            query = entityManager.createQuery(first, Post.class) // 첫번째 쿼리
+                    .setParameter("theme", theme); // 해당 테마 아이디 넣기
+        } else {
+            query = entityManager
+                    .createQuery(paging, Post.class) // lastId 가 있을 경우인데
+                    .setParameter("theme", theme) // 해당 테마 아이디 넣기
+                    .setParameter("lastId", lastId); // lastId 기준으로 이것보다 작은 것들 list, orderBy desc
+        }
+
+        return query
+                .setMaxResults(10) // 5개를 뽑아옵니다.
+                .getResultList(); // list
+    }
+}

--- a/src/main/java/team/compass/post/repository/PostRepository.java
+++ b/src/main/java/team/compass/post/repository/PostRepository.java
@@ -3,20 +3,22 @@ package team.compass.post.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team.compass.post.domain.Post;
+import team.compass.theme.domain.Theme;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post,Integer> {
     //TODO: 글쓰기 o
     //TODO: 글수정 o
     //TODO: 글삭제 o
-    //TODO: 글조회 o
+    //TODO: 글조회 o -> main page select 삭제
     //TODO: 해당 글 조회 (detail) (눌렀을 때) o
-    //TODO: 해당 테마 글 조회 (해당 테마를 누르면 그에 해당되는 글 list 조회)
+    //TODO: 해당 테마 글 조회 (해당 테마를 누르면 그에 해당되는 글 list 조회) o
     //TODO: 글검색 - DB LIKE 로 해결할지
 
     @Query("select p from Post p left join fetch p.photos where p.id = :id")
@@ -25,39 +27,14 @@ public interface PostRepository extends JpaRepository<Post,Integer> {
     @Query("select p from Post p left join fetch  p.likes left join fetch p.user where p.id = :id")
     Optional<Post> findWithLikeById(@Param(value = "id") Integer id); // 단건 조회 (좋아요 수 같이)
 
-    @Query("select p from Post p left join fetch p.likes group by p.id")
-    List<Post> findList(); // 전체 조회 -> main page
+//    @Query("select p from Post p left join fetch p.likes group by p.id")
+//    List<Post> findList(Pageable pageable); // 전체 조회 -> main page -> 쿼리 문제로 인해 좋아요수가 3인 글이 1개로 찍히는 문제
 
-    @Query("select p from Post p left join fetch p.photos pp join fetch pp.photo where p.id in(:id)") // 사진까지 같이 긁어오기
-    List<Post> findListById(@Param(value = "id") List<Integer> id); // photo -> main page
+//    @Query("select p from Post p left join fetch p.likes")
+//    List<Post> findList(Pageable pageable); // 전체 조회 -> main page (like pk 수로 카운팅하면 좋아요 수가 같이 나옴)
+//
+//    @Query("select p from Post p left join fetch p.photos pp join fetch pp.photo where p.id in(:id)") // 사진까지 같이 긁어오기
+//    List<Post> findListById(@Param(value = "id") List<Integer> id); // photo -> main page
 
 }
 
-
-/*
-    TODO : 해당 글 조회
-    쿼리 한 번에 vs 나눠서 (글, 좋아요 + 사진)
-
-    쿼리 한 번에 ?
-
-    SELECT *, (select count(*) from likes l where l.post_id =2 group by l.post_id) as likesCount
-    FROM post p
-    left join  post_photo pp on p.post_id =pp.post_id
-    left join photo p2 on pp.photo_id = p2.photo_id
-    where p.post_id = {};
-
-
-    쿼리 나눠서 하기
-    <- 글, 좋아요 -> (해당 글이 없으면 아예 데이터 출력 X)
-    select *, count(likes_id)
-    from post p
-    left join likes l on p.post_id = l.post_id
-    where p.post_id = {}
-    group by l.post_id;
-
-    <- 사진 ->
-    select * from
-    post_photo pp
-    left join photo p on pp.photo_id = p.photo_id
-    where pp.post_id = {}
- */

--- a/src/main/java/team/compass/post/service/PostService.java
+++ b/src/main/java/team/compass/post/service/PostService.java
@@ -1,18 +1,17 @@
 package team.compass.post.service;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import team.compass.member.domain.User;
 import team.compass.post.domain.Post;
+import team.compass.post.dto.PostDto;
+import team.compass.user.domain.User;
 
 import java.util.List;
 
 @Service
 public interface PostService {
-    // 메인 페이지 select
-    ResponseEntity<Object> mainPageSelect();
 
+    // 메인 페이지 select
     Post write(Post param, List<MultipartFile> multipartFile, User user);
 
     Post update(Post param, List<MultipartFile> multipartFile, User user, Integer postId);
@@ -21,4 +20,6 @@ public interface PostService {
     void delete(Integer postId);
 
     Post getPost(Integer postId);
+
+    List<PostDto> themePageSelect(Integer themeId, Integer lastId);
 }

--- a/src/main/java/team/compass/post/service/PostServiceImpl.java
+++ b/src/main/java/team/compass/post/service/PostServiceImpl.java
@@ -1,13 +1,11 @@
 package team.compass.post.service;
 
 
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import team.compass.member.domain.User;
 import team.compass.photo.domain.Photo;
 import team.compass.photo.repository.PhotoRepository;
 import team.compass.photo.repository.PostPhotoRepository;
@@ -16,152 +14,100 @@ import team.compass.post.domain.Post;
 import team.compass.post.domain.PostPhoto;
 import team.compass.post.dto.PhotoDto;
 import team.compass.post.dto.PostDto;
+import team.compass.post.repository.PostCustomRepository;
 import team.compass.post.repository.PostRepository;
 import team.compass.theme.domain.Theme;
 import team.compass.theme.repository.ThemeRepository;
+import team.compass.user.domain.User;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class PostServiceImpl implements PostService {
 
-    @Autowired
-    private PostRepository postRepository;
 
-    @Autowired
-    private FileUploadService fileUploadService;
+    private final PostRepository postRepository;
 
-    @Autowired
-    private PhotoRepository photoRepository;
-    @Autowired
-    private PostPhotoRepository postPhotoRepository;
 
-    @Autowired
-    private ThemeRepository themeRepository;
+    private final FileUploadService fileUploadService;
 
-    /**
-     * 메인페이지
-     * @return
-     */
-    @Override
-    public ResponseEntity<Object> mainPageSelect() {
-        //좋아요 + post name
-        List<Post> list = postRepository.findList();
-        for (Post post : list) {
-            System.out.println("post = " + post);
-        }
-        //list 가져온걸 id 뽑아옴
-        //1    1번글의1번사진 1번글의2번사진
-        // 2  null
-        // 3  3번글
-        // 4 null
-        List<Integer> postIdList = list.stream().map(Post::getId).collect(Collectors.toList());
-        // postIdList에 대한 사진 정보, 조건문 in
-        List<Post> listById = postRepository.findListById(postIdList);
-        // postId 중복 제거
-        HashSet<Post> posts = new HashSet<>(listById);
-        // 저장할 데이터 (결과)
-        List<PostDto> result = new ArrayList<>();
-        // set 데이터, list 데이터에 있는 id 비교해서 있으면 photo 붙임
-        // 없다면 빼서 null 더하는 방식
-        for (Post post : list) {
-            //처음에 찾은 놈
-            Post post1 = posts.stream().filter(i -> i.getId().equals(post.getId())).findAny().orElse(null);
-            //1
-            //2
-            //3
-            //4
-            if (post1 != null) {
-                result.add(new PostDto(post.getId(), post.getLikes().size(),
-                    post1.getPhotos().stream().map(i -> i.getPhoto().getName()).collect(
-                        Collectors.toList()), post.getTitle(), post.getLocation(), post.getStartDate(),
-                    post.getEndDate()));
-            } else {
-                result.add(new PostDto(
-                    post.getId(),
-                    post.getLikes().size(),
-                    null,
-                    post.getTitle(),
-                    post.getLocation(),
-                    post.getStartDate(),
-                    post.getEndDate())
-                );
-            }
-            //사진
-        }
-        return ResponseEntity.ok().body(result);
-    }
+
+    private final PhotoRepository photoRepository;
+
+    private final PostPhotoRepository postPhotoRepository;
+
+    private final ThemeRepository themeRepository;
+
+    private final PostCustomRepository postCustomRepository;
+
 
     /**
      * 글 작성 (사진 포함 같이)
-     * @return
+     *
+     * 1. post 저장
+     * 2. S3 로직 (사진 API), 사진 저장
+     * 순서 : 글 -> 사진 -> postPhoto
      */
     @Override
     @Transactional
     public Post write(Post createPost, List<MultipartFile> multipartFile, User user) {
-
-        //post 저장
-        //s3 -> 사진 외부 api
-        //사진 저장
-        // 원래는 사진 저장 -> 글 저장 (Post 저장) -> PostPhoto, Photo 저장 순으로 가야함.
-        // 이유는 사진 저장은 외부 API(AWS)를 사용하는 거기에 속도가 느릴 수밖에 없음.
-        // 지금은 1, 2번 순 바뀜.
-        Theme theme = themeRepository.findById(createPost.getTheme().getId()).orElseThrow(() -> new IllegalStateException("없는 테마입니다."));
-        createPost.setTheme(theme);
-        Post post = postRepository.save(createPost); // 글 저장  == Post 저장
-        List<PostPhoto> list = getPhotos(multipartFile, user, post);
-        postPhotoRepository.saveAll(list);
-
+        Theme theme = themeRepository.findById(createPost.getTheme().getId()) // 테마 id 찾기
+                .orElseThrow(() -> new IllegalStateException("없는 테마입니다."));
+        createPost.setTheme(theme); // flush 오류 -> 영속성 컨텍스트에 없어서 불러오기 // 받아온 테마 id 넣어주기
+        Post post = postRepository.save(createPost); // 글 저장  == Post 저장 // 그 결과값들 postRepo 저장해서 다시 post로 묶어주기
+        List<PostPhoto> list = getPhotos(multipartFile, user, post); // 마지막으로 postPhoto에 리스트로 받아오기
+        postPhotoRepository.saveAll(list); // 받아온 데이터들 postPhotoRepo 저장
         return post;
     }
 
-    // 글 업데이트(기존 사진 삭제 -> 새 사진 업로드)
-
+    /**
+     * 글 업데이트(기존 사진 삭제 -> 새 사진 업로드)
+     */
     @Override
     @Transactional
     public Post update(Post updatePost, List<MultipartFile> multipartFile, User user, Integer postId) {
         // post 업데이트
-
-        Post udPost = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+        Post udPost = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
         udPost.setTitle(updatePost.getTitle()); // 제목
         udPost.setLocation(updatePost.getLocation()); // 장소
         udPost.setDetail(updatePost.getDetail()); // 내용
-        // udPost.setCreatedAt(LocalDateTime.now()); // 수정일 -> 근데 등록일 기준으로 나중에 정렬하게 되면.. 이슈가 있을 수도?? 나중의 글 -> 새로 쓴 글로 바뀌어서..
+        // udPost.setCreatedAt(LocalDateTime.now());
+        // 수정일 -> 근데 등록일 기준으로 나중에 정렬하게 되면.. 이슈가 있을 수도?? 나중의 글 -> 새로 쓴 글로 바뀌어서.. -> pk 기준으로 정렬 상관없음
         udPost.setStartDate(updatePost.getStartDate()); // 여행 시작
         udPost.setEndDate(updatePost.getEndDate()); // 여행 끝
         udPost.setHashtag(updatePost.getHashtag()); // 해시태그
-        udPost.setUser(user);
+        udPost.setUser(user); // 나중에 Builder 로 다시 변경할것
 
-        postRepository.save(udPost);
-
+        postRepository.save(udPost); // 업데이트로 쓰인 데이터들 repo 저장
         //사진 저장
         List<PostPhoto> list = getPhotos(multipartFile, user, udPost);
-
         //이전의 사진데이터 삭제 -> 기준이 없기에
         List<PostPhoto> photos = udPost.getPhotos();
-
         postPhotoRepository.deleteAll(photos);
-
         //새로운 사진저장
         postPhotoRepository.saveAll(list);
-
         return udPost;
     }
 
+    /**
+     * 글 삭제
+     * Post entity photos 부분 -> cascade = CascadeType.REMOVE
+     * 함으로써 Post 삭제시 photos 도 삭제됨.
+     * 처리 안 할 경우에 null 이 돼서 fk 가 보는 곳이 없어짐. 아니면 null 처리가 따로 있다던지..
+     */
     @Override
     @Transactional
     public void delete(Integer postId) {
-        // Post entity photos 부분 -> cascade = CascadeType.REMOVE
-        // 함으로써 Post 삭제시 photos 도 삭제됨.
-        // 처리 안 할 경우에 null 이 돼서 fk 가 보는 곳이 없어짐. 아니면 null 처리가 따로 있다던지..
-        postRepository.deleteById(postId);
-
+        postRepository.deleteById(postId); // 삭제
     }
 
+    /**
+     * 사진 저장
+     */
     private List<PostPhoto> getPhotos(List<MultipartFile> multipartFile, User user, Post post) {
         List<PostPhoto> list = new ArrayList<>(); // 사진 저장 리스트
         for (MultipartFile file : multipartFile) {
@@ -172,14 +118,51 @@ public class PostServiceImpl implements PostService {
         return list;
     }
 
+    /**
+     * 해당 글 가져오기
+     */
     @Override
     @Transactional
     public Post getPost(Integer postId) {
         List<PostPhoto> photos = postPhotoRepository.findListById(postId);
         Post post = postRepository.findWithLikeById(postId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
-        post.setPhotos(photos);
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+        post.setPhotos(photos); // 사진 추가하고 리턴
         return post;
     }
 
+    /**
+     * <해당 테마 글 리스트 조회>
+     * fetch join 에는 limit 을 지원하지 않아서 따로 custom repository를 이용하여 sql 문으로 작성해 이용하기
+     * fetch join 을 이용하고 할 경우, likes 수로 인해 raw 가 1개의 글 - 1raw 가 아닌 1개의 글 - 3raw (3개 좋아요) 이런 식으로 나오게 됐다.
+     * 그렇게 될 경우, 10개만 뽑아서 리스트를 가져오고 싶은데 위의 상황으로 인해 2개, 3개,... 이런 식으로밖에 못가져옴.
+     * 그래서 해당 sql 문으로 작성과 properties 에 batch size를 걸어 해당 수만큼 한번에 묶음 형식으로 가져오도록 설정해놨더니 바라던 결과대로 나옴.
+     */
+    @Override
+    @Transactional
+    public List<PostDto> themePageSelect(Integer themeId, Integer lastId) {
+        // 테마 1 id == null
+        // fetch join 에는 limit 을 지원하지 않아서 따로 custom repository를 이용하여 sql 문으로 작성해 이용하기
+        List<Post> postList = postCustomRepository.findByTheme(themeId, lastId); // themeId, LastId 추려서 post 가져오기 (이때 post select 1번)
+        List<PostDto> result = new ArrayList<>(); // postPhoto list 생성
+        // 1 벝 포스트 select like , photos select 문
+        // 2번 째
+        //...
+        // select -> in 쿼리로 (like를 묶어서 5개의 글 조회하는 것임. 현재 5개로 설정해둔 상태)
+        for (Post post : postList) { // post 리스트를 postDto list 에 더해준다.
+            result.add(new PostDto(
+                    post.getId(),
+                    // like
+                    post.getLikes().size(),
+                    // photo list 형식이니 stream
+                    post.getPhotos().stream().map(i -> i.getPhoto().getStoreFileUrl()).collect(Collectors.toList()),
+                    post.getTitle(),
+                    post.getLocation(),
+                    post.getStartDate(),
+                    post.getEndDate())
+            );
+        }
+        List<PostDto> postResult = result; // 그 담아진 결과 5개를 다시 담아서 리턴
+        return postResult;
+    }
 }

--- a/src/main/java/team/compass/theme/repository/ThemeRepository.java
+++ b/src/main/java/team/compass/theme/repository/ThemeRepository.java
@@ -1,8 +1,15 @@
 package team.compass.theme.repository;
 
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import team.compass.theme.domain.Theme;
+
+import java.util.List;
 
 
 public interface ThemeRepository extends JpaRepository<Theme, Integer> {
+
+    @Query("select t from Theme t left join fetch t.post where t.id in(:id)")
+    List<Theme> findListByThemeId(@Param(value = "id") Integer id);
 }

--- a/src/main/java/team/compass/user/controller/UserController.java
+++ b/src/main/java/team/compass/user/controller/UserController.java
@@ -1,4 +1,4 @@
-package team.compass.member.controller;
+package team.compass.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -7,10 +7,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import team.compass.member.dto.MemberRequestDto;
-import team.compass.member.dto.TokenDto;
-import team.compass.member.domain.User;
-import team.compass.member.service.UserService;
+import team.compass.user.dto.TokenDto;
+import team.compass.user.domain.User;
+import team.compass.user.dto.UserRequestDto;
+import team.compass.user.service.UserService;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
@@ -20,7 +20,7 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(
-            @RequestBody MemberRequestDto.SignUp parameter
+            @RequestBody UserRequestDto.SignUp parameter
     ) {
         User user = userService.signUp(parameter);
 
@@ -33,7 +33,7 @@ public class UserController {
 
     @PostMapping("/signin")
     public ResponseEntity<?> signin(
-            @RequestBody MemberRequestDto.SignIn parameter
+            @RequestBody UserRequestDto.SignIn parameter
     ) {
         TokenDto tokenDto = userService.signIn(parameter);
 

--- a/src/main/java/team/compass/user/domain/RefreshToken.java
+++ b/src/main/java/team/compass/user/domain/RefreshToken.java
@@ -1,4 +1,4 @@
-package team.compass.member.domain;
+package team.compass.user.domain;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/team/compass/user/domain/User.java
+++ b/src/main/java/team/compass/user/domain/User.java
@@ -1,4 +1,4 @@
-package team.compass.member.domain;
+package team.compass.user.domain;
 
 
 import lombok.AllArgsConstructor;
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import team.compass.member.dto.MemberRequestDto;
+import team.compass.user.dto.UserRequestDto;
 
 import javax.persistence.*;
 import java.util.*;
@@ -45,6 +45,7 @@ public class User implements UserDetails {
     // 권한 추가?????
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles = new ArrayList<>();
+
 
 
 
@@ -85,7 +86,7 @@ public class User implements UserDetails {
         return true;
     }
 
-    public static User from(MemberRequestDto.SignUp parameter) {
+    public static User from(UserRequestDto.SignUp parameter) {
         return User.builder()
                 .email(parameter.getEmail().toLowerCase(Locale.ROOT))
                 .password(parameter.getPassword())

--- a/src/main/java/team/compass/user/dto/TokenDto.java
+++ b/src/main/java/team/compass/user/dto/TokenDto.java
@@ -1,4 +1,4 @@
-package team.compass.member.dto;
+package team.compass.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/team/compass/user/dto/UserRequestDto.java
+++ b/src/main/java/team/compass/user/dto/UserRequestDto.java
@@ -1,12 +1,12 @@
-package team.compass.member.dto;
+package team.compass.user.dto;
 
 import lombok.Builder;
 import lombok.Data;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 
 import javax.validation.constraints.NotEmpty;
 
-public class MemberRequestDto {
+public class UserRequestDto {
     @Data
     @Builder
     public static class SignIn {

--- a/src/main/java/team/compass/user/dto/UserResponseDto.java
+++ b/src/main/java/team/compass/user/dto/UserResponseDto.java
@@ -1,21 +1,21 @@
-package team.compass.member.dto;
+package team.compass.user.dto;
 
 import lombok.*;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MemberResponseDto {
+public class UserResponseDto {
     private Integer userId;
     private String email;
     private String nickName;
     private String accessToken;
 
-    public static MemberResponseDto to(User user, String accessToken) {
-        return MemberResponseDto.builder()
+    public static UserResponseDto to(User user, String accessToken) {
+        return UserResponseDto.builder()
                 .userId(user.getUserId())
                 .email(user.getEmail())
                 .nickName(user.getNickName())

--- a/src/main/java/team/compass/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/team/compass/user/repository/RefreshTokenRepository.java
@@ -1,8 +1,8 @@
-package team.compass.member.repository;
+package team.compass.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import team.compass.member.domain.RefreshToken;
+import team.compass.user.domain.RefreshToken;
 
 import java.util.Optional;
 

--- a/src/main/java/team/compass/user/repository/UserRepository.java
+++ b/src/main/java/team/compass/user/repository/UserRepository.java
@@ -1,8 +1,8 @@
-package team.compass.member.repository;
+package team.compass.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import team.compass.member.domain.User;
+import team.compass.user.domain.User;
 
 import java.util.Optional;
 

--- a/src/main/java/team/compass/user/service/UserService.java
+++ b/src/main/java/team/compass/user/service/UserService.java
@@ -1,4 +1,4 @@
-package team.compass.member.service;
+package team.compass.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -6,12 +6,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.compass.common.config.JwtTokenProvider;
-import team.compass.member.domain.User;
-import team.compass.member.dto.MemberRequestDto;
-import team.compass.member.dto.TokenDto;
-import team.compass.member.domain.RefreshToken;
-import team.compass.member.repository.RefreshTokenRepository;
-import team.compass.member.repository.UserRepository;
+import team.compass.user.domain.User;
+import team.compass.user.dto.TokenDto;
+import team.compass.user.domain.RefreshToken;
+import team.compass.user.dto.UserRequestDto;
+import team.compass.user.repository.RefreshTokenRepository;
+import team.compass.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +22,7 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
 
 //    @Transactional
-    public User signUp(MemberRequestDto.SignUp parameter) {
+    public User signUp(UserRequestDto.SignUp parameter) {
         boolean existsByEmail = memberRepository.existsByEmail(parameter.getEmail());
 
         if(existsByEmail) {
@@ -31,14 +31,14 @@ public class UserService {
 
         parameter.setPassword(passwordEncoder.encode(parameter.getPassword()));
 
-        User user = memberRepository.save(MemberRequestDto.SignUp.toEntity(parameter));
+        User user = memberRepository.save(UserRequestDto.SignUp.toEntity(parameter));
 
         return user;
     }
 
 //    @Transactional
 //    public User signIn(MemberRequestDto.SignIn parameter) {
-    public TokenDto signIn(MemberRequestDto.SignIn parameter) {
+    public TokenDto signIn(UserRequestDto.SignIn parameter) {
         User user = memberRepository.findByEmail(parameter.getEmail())
                 .orElseThrow(() -> new RuntimeException("해당 회원이 존재하지 않습니다."));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,3 +30,5 @@ jwt.refresh-token-expire-time=604800000
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 # server port
 server.port=8080
+# batch size
+spring.jpa.properties.hibernate.default_batch_fetch_size= 50


### PR DESCRIPTION
## 테마 별 글 조회, 페이징 처리(무한 스크롤)
###  📌**메인 페이지 삭제**
와이어 프레임을 확인해 보니, 테마 별 글 조회로 페이지 처리가 되어 있어 해당 기능을 삭제하였습니다. 추후에 전체 글 조회도 있을 가능성을 보아 PostRepository에서 해당 기능을 수행하는 메서드들을 주석처리 해놓은 상태입니다.
###  📌 **테마 별 글 조회**
PostCustomRepository 를 만들어 따로 쿼리문을 작성합니다. 이유는 jpa fetch join에서 limit을 지원하지 않기 때문입니다. limit을 지원하지 않는다면 원래 있던 쿼리로 실행할 경우, 좋아요가 3개인 글을 조회할 때 3번의 raw가 나오게 되어 실제로 1x3 의 select가 나갑니다. 

때문에 batch size (application.properties 확인하실 수 있습니다.) 50을 걸어 두어 50개까지는 한 번에 나가도록 묶어서 처리합니다. fetch 의 limit 부분과 lazy (지연 로딩)를 처리할 수 있게 된 것입니다. 
때문에 실제 쿼리를 확인해보면
![image](https://user-images.githubusercontent.com/119172260/231973835-0902aec8-15bc-4ad9-8aa0-8caca387352d.png)

post, likes, photo가 select  하나씩 묶여서 한 번에 쿼리를 보낼 수 있게 됐습니다.

![image](https://user-images.githubusercontent.com/119172260/231974123-9bdc829e-69ef-4c45-ae92-7ccaf7ac3cfc.png)

limit 와 in 절을 통해서 원했던 결과와 in 절 안이 곧 raw 수인 것을 확인할 수 있습니다.

###  📌 **페이징처리(무한 스크롤)**
 
parameter 값으로 themeId, lastId 를 받습니다. 하지만 첫 페이지는 lastId 값을 받지 않습니다. 가장 최신의 글은 좌측 상단으로, 오래된 글은 우측 하단으로 나올 것입니다. 따라서 일정 스크롤을 내려 화면을 뿌려줘야할 경우 보여지는 화면에서 우측 하단에 있는 postId가 곧 lastId가 될 것이며, 그 Id 기준으로 다시 글들을 select 해서 가져옵니다. 

원래는 lastId를 처리하지 않고, 전체 페이지 (필요한 글은 10개이나 42개까지 긁어옴)를 가져와 필요할 때마다 잘라서 보내주는 형식이었습니다. 하지만 그럴 경우 여러 유저가(500명) 테마들을 하나씩 누를 때마다 100개의 글을 500 x 100 select 해야되는 상황이 오면 서버가 터질 우려가 있기에 이것도 위와 마찬가지로 처리하였습니다.

### 📌 사용자 네이밍 변경

통합을 위하여 member 키워드를 전부 다 user 로 변경하였습니다.