### PR TITLE
Feat : ResponseUtil 추가, AWS S3 baseUrl, toEntity

### DIFF
--- a/src/main/java/team/compass/common/config/SwaggerConfig.java
+++ b/src/main/java/team/compass/common/config/SwaggerConfig.java
@@ -18,7 +18,7 @@ public class SwaggerConfig {
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
             .select()
-            .apis(RequestHandlerSelectors.basePackage("com.example.demo")) // 경로 설정해주기
+            .apis(RequestHandlerSelectors.basePackage("team.compass")) // 경로 설정해주기
             .paths(PathSelectors.any()) // path 기준으로 swagger 에 api 표시
             .build()
             .apiInfo(apiInfo());

--- a/src/main/java/team/compass/common/utils/ResponseUtils.java
+++ b/src/main/java/team/compass/common/utils/ResponseUtils.java
@@ -1,0 +1,36 @@
+package team.compass.common.utils;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResponseUtils {
+    public static ResponseEntity<Object> ok(String message, Object result) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("isSuccess", true);
+        response.put("code", HttpStatus.OK.value());
+        response.put("message", message);
+        response.put("result", result);
+        return ResponseEntity.ok(response);
+    }
+
+    public static ResponseEntity<Object> notFound(String message) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("isSuccess", false);
+        response.put("code", HttpStatus.NOT_FOUND.value());
+        response.put("message", message);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+
+    public static ResponseEntity<Object> badRequest(String message) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("isSuccess", false);
+        response.put("code", HttpStatus.BAD_REQUEST.value());
+        response.put("message", message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+}
+

--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -6,13 +6,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import team.compass.common.utils.ResponseUtils;
 import team.compass.post.controller.request.PostRequest;
 import team.compass.post.controller.response.PostResponse;
 import team.compass.post.domain.Post;
+import team.compass.post.dto.PostDto;
 import team.compass.post.service.PostService;
+import team.compass.theme.domain.Theme;
 import team.compass.user.domain.User;
 import team.compass.user.repository.UserRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -32,33 +36,51 @@ public class PostController {
             @RequestParam(defaultValue = "1") Integer themeId) {
         // 아무데이터도 안들어왔을때
         // 기본값으로 theme 1 로 들어감 last id = null
-        return  ResponseEntity.ok(postService.themePageSelect(themeId, lastId));
+//        return  ResponseEntity.ok(postService.themePageSelect(themeId, lastId));
+
+        if (themeId > 10) {
+            return ResponseUtils.notFound("테마 글 리스트를 찾을 수 없습니다.");
+        }
+
+        List<PostDto> posts = postService.themePageSelect(themeId, lastId);
+
+        if (posts != null) {
+            return ResponseUtils.ok("테마 글 리스트 조회에 성공하였습니다.", posts);
+        } else {
+            return ResponseUtils.notFound("테마 글 리스트를 찾을 수 없습니다.");
+        }
     }
 
     @ApiOperation(value = "글 쓰기 api 입니다.", notes = "글작성, 사진첨부까지 함께 저장합니다.")
     @PostMapping(value = "/post")
     @Transactional
     public ResponseEntity<Object> postWrite(
-            @RequestPart(value = "data") PostRequest post, // request post 로 받아오기. 내용들
-            @RequestPart(value = "images") List<MultipartFile> images) { // 이미지 받아오기
+            @RequestPart(value = "data") PostRequest postRequest, // request post 로 받아오기. 내용들
+            @RequestPart(value = "images") List<MultipartFile> images,
+            Theme theme) { // 이미지 받아오기
 
         validationPhoto(images); // 유효성 검증(이미지 최대 5개까지 받아올 수 있게)
         User user = userRepository.findById(1)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // 임시로 넣어둔 유저
 
-        Post postEntity = post.toEntity(); // toEntity -> 넣어주기
+        Post postEntity = getPostEntity(postRequest); // toEntity -> 넣어주기 ( 📌이 부분 고칠것)
         postEntity.setUser(user); // toEntity 에 user 값 넣기
 
         Post write = postService.write(postEntity, images, user); // 받았던 글 post(글과 사진, 유저) write 에 담기
 
-        return ResponseEntity.ok(write);
+//        return ResponseEntity.ok(write);
+        if (write != null) {
+            return ResponseUtils.ok("글을 작성하였습니다.", write);
+        } else {
+            return ResponseUtils.notFound("글 작성에 실패하였습니다.");
+        }
     }
 
     @ApiOperation(value = "글 수정 api 입니다.", notes = "글 수정, 사진 수정")
     @Transactional
     @PutMapping(value = "/post/{postId}")
     public ResponseEntity<Object> postUpdate(
-            @RequestPart(value = "data") PostRequest post,
+            @RequestPart(value = "data") PostRequest postRequest,
             @RequestPart(value = "images") List<MultipartFile> images,
             @PathVariable Integer postId) { // 글 id 받기 위해
 
@@ -66,9 +88,15 @@ public class PostController {
         User user = userRepository.findById(1)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // user 체크
 
-        Post updatePost = postService.update(post.toEntity(), images, user, postId); // 업데이트 받아온 것 저장
+        Post updatePost = postService.update(getPostEntity(postRequest), images, user, postId); // 업데이트 받아온 것 저장
 
-        return ResponseEntity.ok(new PostResponse(updatePost)); // response 에 담아 보내기
+//        return ResponseEntity.ok(new PostResponse(updatePost)); // response 에 담아 보내기
+
+        if (updatePost != null) {
+            return ResponseUtils.ok("글을 수정하였습니다.", new PostResponse(updatePost));
+        } else {
+            return ResponseUtils.badRequest("글 수정에 실패하였습니다.");
+        }
     }
 
     @ApiOperation(value = "글 삭제 api 입니다.", notes = "해당 글을 삭제하면 연관되어 있는 해당 글, 사진, 좋아요, 댓글 삭제됩니다.")
@@ -77,8 +105,14 @@ public class PostController {
     public ResponseEntity<Object> postDelete(@PathVariable Integer postId) {
         User user = userRepository.findById(1)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // user 체크
-        postService.delete(postId);
-        return ResponseEntity.ok("삭제되었습니다.");
+//        postService.delete(postId);
+//        return ResponseEntity.ok("삭제되었습니다.");
+        boolean isDeleted = postService.delete(postId);
+        if (isDeleted) {
+            return ResponseUtils.ok("글을 삭제하였습니다.", null);
+        } else {
+            return ResponseUtils.badRequest("글 삭제에 실패하였습니다.");
+        }
     }
 
     @ApiOperation(value = "글 상세 보기 입니다.", notes = "해당 글 상세 보기.")
@@ -86,15 +120,35 @@ public class PostController {
     @GetMapping(value = "/post/{postId}")
     public ResponseEntity<Object> getPost(@PathVariable Integer postId) {
         Post post = postService.getPost(postId);
-        return ResponseEntity.ok(new PostResponse(post));
+//        return ResponseEntity.ok(new PostResponse(post));
+        if (post != null) {
+            return ResponseUtils.ok("글 조회에 성공하였습니다.", new PostResponse(post));
+        } else {
+            return ResponseUtils.notFound("해당 글을 찾을 수 없습니다.");
+        }
     }
 
 
     // 사진 5개 등록 제한걸어두기
+
     private static void validationPhoto(List<MultipartFile> images) {
         if (images.size() > 5) {
             throw new IllegalArgumentException("사진은 5장까지만 등록 가능합니다.");
         }
+    }
+
+    // toEntity 제거
+    private static Post getPostEntity(PostRequest post) {
+        return Post.builder()
+                .title(post.getTitle())
+                .detail(post.getDetail())
+                .location(post.getLocation()) // 지역
+                .hashtag(post.getHashtag()) // 해시태그
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .theme(new Theme(post.getThemeId()))
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 }
 

--- a/src/main/java/team/compass/post/controller/request/PostRequest.java
+++ b/src/main/java/team/compass/post/controller/request/PostRequest.java
@@ -25,16 +25,17 @@ public class PostRequest {
     private Integer themeId;
 
     // DTO - ENTITY (toEntity를 DTO 에서 해주는 것.) Entity 는 테이블 그 자체이기에 건들면 위험함
-    public Post toEntity() {
-        return Post.builder()
-                .title(title)
-                .detail(detail)
-                .location(location) // 지역
-                .hashtag(hashtag) // 해시태그
-                .startDate(startDate)
-                .endDate(endDate)
-                .theme(new Theme(this.themeId))
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
+//    public Post toEntity() {
+//        return Post.builder()
+//                .title(title)
+//                .detail(detail)
+//                .location(location) // 지역
+//                .hashtag(hashtag) // 해시태그
+//                .startDate(startDate)
+//                .endDate(endDate)
+//                .theme(new Theme(this.themeId))
+//                .createdAt(LocalDateTime.now())
+//                .build();
+//    }
+    // from (param 1), of (N개, 너무 많지 않게..)
 }

--- a/src/main/java/team/compass/post/controller/response/PostResponse.java
+++ b/src/main/java/team/compass/post/controller/response/PostResponse.java
@@ -24,6 +24,9 @@ public class PostResponse {
     private String hashtag; // 해시태그 (프론트에서 받아옴, #마다 잘라서 문자로 들어옴)
     private String startDate; // 여행 시작일 (프론트에서 문자열로 받아옴)
     private String endDate; // 여행 끝난일 (프론트에서 문자열로 받아옴)
+
+    private final String baseUrl = "https://compass-s3-bucket.s3.ap-northeast-2.amazonaws.com/"; // 추가
+
     private List<String> storeFileUrl;
     private Integer likeCount;
     private String nickname;

--- a/src/main/java/team/compass/post/domain/Post.java
+++ b/src/main/java/team/compass/post/domain/Post.java
@@ -78,4 +78,7 @@ public class Post {
     private Theme theme; // 테마
 
 
+    public Post(Integer postId) {
+        this.id = postId;
+    }
 }

--- a/src/main/java/team/compass/post/dto/PostDto.java
+++ b/src/main/java/team/compass/post/dto/PostDto.java
@@ -1,16 +1,21 @@
 package team.compass.post.dto;
 
-import java.time.LocalDateTime;
+import lombok.*;
+
 import java.util.List;
 
-import lombok.Builder;
-import lombok.Data;
 
-
-@Data
+//@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostDto {
     private Integer postId;
     private Integer likeCount;
+
+    private final String baseUrl = "https://compass-s3-bucket.s3.ap-northeast-2.amazonaws.com/"; // 기본 주소 추가
+
     private List<String> storeFileUrl;
 
     private String title;
@@ -19,38 +24,4 @@ public class PostDto {
 
     private String startDate;
     private String endDate;
-
-    public PostDto(Integer postId, Integer likeCount, List<String> storeFileUrl, String title, String location, String startDate, String endDate) {
-        this.postId = postId;
-        this.likeCount = likeCount;
-        this.storeFileUrl = storeFileUrl;
-        this.title = title;
-        this.location = location;
-        this.startDate = startDate;
-        this.endDate = endDate;
-    }
-
 }
-
-
-// @Data
-// static class PostDto {
-//     @Override
-//     public String toString() {
-//         return "PostDto{" +
-//             "postName=" + postName +
-//             ", likeCount=" + likeCount +
-//             ", photoName=" + photoName +
-//             '}';
-//     }
-//
-//     private Long postName;
-//     private Integer likeCount;
-//     private List<String> photoName;
-//
-//     public PostDto(Long postName, Integer likeCount, List<String> photoName) {
-//         this.postName = postName;
-//         this.likeCount = likeCount;
-//         this.photoName = photoName;
-//     }
-// }

--- a/src/main/java/team/compass/post/repository/PostRepository.java
+++ b/src/main/java/team/compass/post/repository/PostRepository.java
@@ -1,15 +1,12 @@
 package team.compass.post.repository;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team.compass.post.domain.Post;
-import team.compass.theme.domain.Theme;
+
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post,Integer> {

--- a/src/main/java/team/compass/post/service/PostService.java
+++ b/src/main/java/team/compass/post/service/PostService.java
@@ -17,7 +17,8 @@ public interface PostService {
     Post update(Post param, List<MultipartFile> multipartFile, User user, Integer postId);
 
 
-    void delete(Integer postId);
+//    void delete(Integer postId);
+    boolean delete(Integer postId);
 
     Post getPost(Integer postId);
 


### PR DESCRIPTION
## ResponseUtil 추가, AWS S3 baseUrl

* ## AWS S3 baseUrl 
기존에 있던 GET 방식의 글 조회들은 해당 사진들의 S3 키값만을 Response로 내려줬었습니다. 하지만 이 결과값은 프론트에서 사진을 확인할 수 없어, baseUrl(AWS S3 버킷 주소)를 추가하여, baseUrl + 키값을 이용하여 프론트에서 사진을 조회할 수 있게 추가하였습니다. 
![스크린샷 2023-04-16 184310](https://user-images.githubusercontent.com/119172260/232291797-20b63deb-98cb-4dc3-95c5-dcafb06c84c3.png)

* ## ResponseUtil 추가
커스텀하여 ResponseUtil 클래스를 추가하였습니다. 기존의 Response는 응답결과와 상태코드, 해당 메시지를 포함하지 않았습니다. API 명세서를 내려주기 위하여 해당 클래스를 커스텀하여 공통으로 쓰이게 만들었습니다. 
해당 ResponseUtil 클래스는 이렇습니다.
![스크린샷 2023-04-16 185756](https://user-images.githubusercontent.com/119172260/232292281-04c8222c-34a7-4771-8658-5157e8c077d2.png)

저의 PostController에서의 예시를 들어보겠습니다. ResponseEntity 타입이므로 null의 상황도 고려하여 if 문으로 null 체크를 했습니다.
![스크린샷 2023-04-16 190358](https://user-images.githubusercontent.com/119172260/232292626-764c9d32-2232-4b27-bdd0-db547d47661e.png)
위의 예제로 글 작성에 성공할 경우, 응답결과(isSuccess : true), 상태코드(code : 200), 메시지(message : 글을 작성하였습니다.)가 추가되었고, result 값으로 기존에 있던 결과값을 내려주게 됩니다. 

* ## toEntity
멘토링 때 멘토님께 조언을 들어, 기존에 있던 toEntity를 빼내어 private method로 추출하여 재사용성을 늘림과 의존성을 한 곳으로 모을 수 있게 되었습니다.
![스크린샷 2023-04-16 184819](https://user-images.githubusercontent.com/119172260/232293488-81baf171-1001-4cb8-ab89-748e95a19a59.png)
