### PR TITLE
Refactor : entity graph 추가, 글 상세보기 댓글 수 확인, User id(PK) 변수명 변경

### DIFF
--- a/src/main/java/team/compass/comment/repository/CommentRepository.java
+++ b/src/main/java/team/compass/comment/repository/CommentRepository.java
@@ -5,7 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.compass.comment.domain.Comment;
 
+import java.util.Optional;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment,Integer> {
-
+    // Post 상세 글 보기 댓글 수 확인
+    Long countByPostId(Integer postId);
 }

--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -56,9 +56,7 @@ public class PostController {
     @Transactional
     public ResponseEntity<Object> postWrite(
             @RequestPart(value = "data") PostRequest postRequest, // request post 로 받아오기. 내용들
-            @RequestPart(value = "images") List<MultipartFile> images,
-    Theme theme) { // 이미지 받아오기
-
+            @RequestPart(value = "images") List<MultipartFile> images) { // 이미지 받아오기
         validationPhoto(images); // 유효성 검증(이미지 최대 5개까지 받아올 수 있게)
         User user = userRepository.findById(1)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // 임시로 넣어둔 유저
@@ -119,10 +117,10 @@ public class PostController {
     @Transactional(readOnly = true)
     @GetMapping(value = "/post/{postId}")
     public ResponseEntity<Object> getPost(@PathVariable Integer postId) {
-        Post post = postService.getPost(postId);
-//        return ResponseEntity.ok(new PostResponse(post));
+        PostResponse post = postService.getPost(postId);
+
         if (post != null) {
-            return ResponseUtils.ok("글 조회에 성공하였습니다.", new PostResponse(post));
+            return ResponseUtils.ok("글 조회에 성공하였습니다.", post);
         } else {
             return ResponseUtils.notFound("해당 글을 찾을 수 없습니다.");
         }

--- a/src/main/java/team/compass/post/controller/response/PostResponse.java
+++ b/src/main/java/team/compass/post/controller/response/PostResponse.java
@@ -29,8 +29,24 @@ public class PostResponse {
 
     private List<String> storeFileUrl;
     private Integer likeCount;
+
+    private Long commentCount;
     private String nickname;
 
+    public PostResponse(Post post, Long aLong) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.detail = post.getDetail();
+        this.location = post.getLocation();
+        this.createdAt = post.getCreatedAt();
+        this.hashtag = post.getHashtag();
+        this.startDate = post.getStartDate();
+        this.endDate = post.getEndDate();
+        this.storeFileUrl = post.getPhotos().stream().map(i->i.getPhoto().getStoreFileUrl()).collect(Collectors.toList());
+        this.likeCount = post.getLikes().size();
+        this.commentCount=aLong;
+        this.nickname=post.getUser().getNickName();
+    }
     public PostResponse(Post post) {
         this.id = post.getId();
         this.title = post.getTitle();
@@ -44,5 +60,6 @@ public class PostResponse {
         this.likeCount = post.getLikes().size();
         this.nickname=post.getUser().getNickName();
     }
+
 
 }

--- a/src/main/java/team/compass/post/domain/Post.java
+++ b/src/main/java/team/compass/post/domain/Post.java
@@ -3,17 +3,7 @@ package team.compass.post.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
+import javax.persistence.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +25,14 @@ import team.compass.theme.domain.Theme;
 @AllArgsConstructor
 @Builder
 @Setter
+@NamedEntityGraph(name = "Post.withAll",attributeNodes = {
+        @NamedAttributeNode("theme"),
+        @NamedAttributeNode("contents"),
+        @NamedAttributeNode("likes"),
+        @NamedAttributeNode("user"), // 관계 알림
+        @NamedAttributeNode(value = "photos",subgraph = "photos")} // photos 서브그래프 지정(value = Post 안의 photos, 네이밍)
+        ,subgraphs = @NamedSubgraph(name ="photos",attributeNodes = {@NamedAttributeNode("photo")})
+) // PostPhoto -> Photo 는 객체 그래프가 아니므로 서브 그래프로 지정해야만 한다. (참조되게!) NamedAttributeNode 속성을 이용해 photo 라는 이름의 서브 그래프.
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team/compass/post/repository/PostCustomRepository.java
+++ b/src/main/java/team/compass/post/repository/PostCustomRepository.java
@@ -1,9 +1,12 @@
 package team.compass.post.repository;
 
+import org.springframework.data.repository.query.Param;
 import team.compass.post.domain.Post;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostCustomRepository  {
     List<Post> findByTheme(Integer theme, Integer lastId);
+    Optional<Post> findWithLikeById(@Param(value = "id") Integer id);
 }

--- a/src/main/java/team/compass/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/team/compass/post/repository/PostCustomRepositoryImpl.java
@@ -1,12 +1,19 @@
 package team.compass.post.repository;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team.compass.post.domain.Post;
 
+import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
+import javax.persistence.Subgraph;
 import javax.persistence.TypedQuery;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,18 +30,39 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         TypedQuery<Post> query=null;
 
-        if (lastId == null) { // ���� lastId �� null �� ���
-            query = entityManager.createQuery(first, Post.class) // ù��° ����
-                    .setParameter("theme", theme); // �ش� �׸� ���̵� �ֱ�
+        if (lastId == null) {
+            query = entityManager.createQuery(first, Post.class)
+                    .setParameter("theme", theme);
         } else {
             query = entityManager
-                    .createQuery(paging, Post.class) // lastId �� ���� ����ε�
-                    .setParameter("theme", theme) // �ش� �׸� ���̵� �ֱ�
-                    .setParameter("lastId", lastId); // lastId �������� �̰ͺ��� ���� �͵� list, orderBy desc
+                    .createQuery(paging, Post.class)
+                    .setParameter("theme", theme)
+                    .setParameter("lastId", lastId); // lastId 기준으로 list, orderBy desc
         }
 
         return query
-                .setMaxResults(10) // 5���� �̾ƿɴϴ�.
+                .setMaxResults(10) // 10개 제한
                 .getResultList(); // list
+    }
+
+    /**
+     *  javax.persistence.fetchgraph 말고도 loadgraph 가 존재한다. 해당 속성은 엔티티 그래프에 선택한
+     *  속성뿐만 아니라 글로벌 fetch 모드가 EAGER로 설정된 연관관계도 포함해 조회하게 된다.
+     *  여기서 사용한 fetchgraph는 선택한 속성만 조회하는 모드이다.
+     *  엔티티 그래프는 항상 ROOT(Post) 에서 시작할 것.
+     *  이미 로딩된 엔티티는 적용되지 않는다. 하지만 아직 초기화 되지 않은 프록시엔 적용 가능!
+     */
+    @Override
+    public Optional<Post> findWithLikeById(@Param(value = "id") Integer id){
+
+        EntityGraph<Post> entityGraph = entityManager.createEntityGraph(Post.class);
+        entityGraph.addAttributeNodes("photos","user");
+
+        Subgraph<Object> photos = entityGraph.addSubgraph("photos"); // 서브그래프 더해주기
+        photos.addAttributeNodes("photo");
+
+        Map<String,Object> hints = new HashMap<>();
+        hints.put("javax.persistence.fetchgraph", entityGraph);
+        return Optional.ofNullable(entityManager.find(Post.class, id, hints));
     }
 }

--- a/src/main/java/team/compass/post/repository/PostRepository.java
+++ b/src/main/java/team/compass/post/repository/PostRepository.java
@@ -18,11 +18,8 @@ public interface PostRepository extends JpaRepository<Post,Integer> {
     //TODO: 해당 테마 글 조회 (해당 테마를 누르면 그에 해당되는 글 list 조회) o
     //TODO: 글검색 - DB LIKE 로 해결할지
 
-    @Query("select p from Post p left join fetch p.photos where p.id = :id")
-    Optional<Post> findById(@Param(value = "id") Integer id); // 단건 조회 (사진)
 
-    @Query("select p from Post p left join fetch  p.likes left join fetch p.user where p.id = :id")
-    Optional<Post> findWithLikeById(@Param(value = "id") Integer id); // 단건 조회 (좋아요 수 같이)
+
 
 //    @Query("select p from Post p left join fetch p.likes group by p.id")
 //    List<Post> findList(Pageable pageable); // 전체 조회 -> main page -> 쿼리 문제로 인해 좋아요수가 3인 글이 1개로 찍히는 문제

--- a/src/main/java/team/compass/post/service/PostService.java
+++ b/src/main/java/team/compass/post/service/PostService.java
@@ -2,6 +2,7 @@ package team.compass.post.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import team.compass.post.controller.response.PostResponse;
 import team.compass.post.domain.Post;
 import team.compass.post.dto.PostDto;
 import team.compass.user.domain.User;
@@ -11,7 +12,7 @@ import java.util.List;
 @Service
 public interface PostService {
 
-    // 메인 페이지 select
+
     Post write(Post param, List<MultipartFile> multipartFile, User user);
 
     Post update(Post param, List<MultipartFile> multipartFile, User user, Integer postId);
@@ -20,7 +21,8 @@ public interface PostService {
 //    void delete(Integer postId);
     boolean delete(Integer postId);
 
-    Post getPost(Integer postId);
+    PostResponse getPost(Integer postId);
+
 
     List<PostDto> themePageSelect(Integer themeId, Integer lastId);
 }

--- a/src/main/java/team/compass/post/service/PostServiceImpl.java
+++ b/src/main/java/team/compass/post/service/PostServiceImpl.java
@@ -5,10 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import team.compass.comment.repository.CommentRepository;
 import team.compass.photo.domain.Photo;
 import team.compass.photo.repository.PhotoRepository;
 import team.compass.photo.repository.PostPhotoRepository;
 import team.compass.photo.service.FileUploadService;
+import team.compass.post.controller.response.PostResponse;
 import team.compass.post.domain.Post;
 import team.compass.post.domain.PostPhoto;
 import team.compass.post.dto.PhotoDto;
@@ -41,6 +43,8 @@ public class PostServiceImpl implements PostService {
     private final ThemeRepository themeRepository;
 
     private final PostCustomRepository postCustomRepository;
+
+    private final CommentRepository commentRepository;
 
 
     /**
@@ -128,14 +132,14 @@ public class PostServiceImpl implements PostService {
      * 해당 글 가져오기
      */
     @Override
-    @Transactional
-    public Post getPost(Integer postId) {
-        List<PostPhoto> photos = postPhotoRepository.findListById(postId);
-        Post post = postRepository.findWithLikeById(postId)
+    @Transactional(readOnly = true)
+    public PostResponse getPost(Integer postId) {
+        Post post = postCustomRepository.findWithLikeById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
-        post.setPhotos(photos); // 사진 추가하고 리턴
-        return post;
+        Long commentCount = commentRepository.countByPostId(postId);
+        return new PostResponse(post, commentCount);
     }
+
 
     /**
      * <해당 테마 글 리스트 조회>

--- a/src/main/java/team/compass/user/domain/User.java
+++ b/src/main/java/team/compass/user/domain/User.java
@@ -25,8 +25,8 @@ import java.util.stream.Collectors;
 public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(nullable = false)
-    private Integer userId;
+    @Column(nullable = false,name = "user_id")
+    private Integer id;
 
     @Column(unique = true, nullable = false)
     private String email;

--- a/src/main/java/team/compass/user/dto/UserResponse.java
+++ b/src/main/java/team/compass/user/dto/UserResponse.java
@@ -15,7 +15,7 @@ public class UserResponse {
 
     public static UserResponse to(User user) {
         return UserResponse.builder()
-                .userId(user.getUserId())
+                .userId(user.getId())
                 .email(user.getEmail())
                 .nickName(user.getNickName())
                 .build();

--- a/src/main/java/team/compass/user/service/UserServiceImpl.java
+++ b/src/main/java/team/compass/user/service/UserServiceImpl.java
@@ -81,7 +81,7 @@ public class UserServiceImpl implements UserService {
         String encodedPassword = passwordEncoder.encode(parameter.getPassword());
 
         User updateUser = User.builder()
-                            .userId(user.getUserId())
+                            .id(user.getId())
                             .email(user.getEmail())
                             .password(encodedPassword)
                             .build();


### PR DESCRIPTION
## entity graph 추가, 글 상세보기 댓글 수 확인, User id(PK) 변수명 변경

* ### entity graph 추가
![image](https://user-images.githubusercontent.com/119172260/232559213-3a65f4f2-d78c-4535-b797-676bc5991d39.png)
기존에 fetch join 을 이용해 쿼리를 작성해서 로직을 수행했다면, entity graph를 이용해서 조회할 수 있게 되었습니다. @NamedAttributeNode 을 이용해 Post(ROOT)에서의 관계를 알리고, Post - PostPhoto - Photo의 조회를 위해 서브 그래프를 이용합니다. @NamedSubgraph 안의 속성을 걸어서 Post 안의 Photos(PostPhoto)을 바라보게 만들어 줍니다.

주의사항과 사용법은 아래에 사진으로 기재하겠습니다.
![image](https://user-images.githubusercontent.com/119172260/232560893-e73c70cf-8c37-4d7d-ac6e-fc583b4ab2f3.png)

* ### 글 상세 보기의 댓글 수 확인
CommentRepository 안에 해당 메서드를 작성하였습니다. JPA 에서 countBy의 결과값은 Long 타입이기에 타입을 Long으로 지정합니다.
` Long countByPostId(Integer postId);`
PostServiceImpl 단에서 해당 글 상세보기 기능 안에 매개변수 값으로 PostId 값을 받아 진행합니다.

* ### User id (PK) 변수명 변경

기존에 userId 로 되어 있던 변수명이 다른 로직에서 findById 메서드가 id 값을 찾지 못하는 이슈가 있었습니다. 

"Caused by: org.springframework.data.mapping.PropertyReferenceException: No property 컬럼명 found for type Entity명! Did you mean 'Entity에_있는_컬럼명'?"

따라서 변수명을 id로 변경하고, 컬럼 네이밍을 user_id 로 넘겨 주었습니다. 이 부분에 관해서, user 단에서만 userId -> id로 변경하였습니다. 

**merge 과정에서 코드가 변경될 우려를 생각하여 like, comment 부분은 commit & push 을 하지 않았습니다.** 확인 하시고 따로 변경하시면 될 거 같습니다. CommentRepository 부분도 확인 한 번 해주시면 감사하겠습니다.