### PR TITLE
Refactor : PostController 유저 로그인 검증 추가(작성, 수정, 삭제)

### DIFF
--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -3,9 +3,11 @@ package team.compass.post.controller;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import team.compass.common.config.JwtTokenProvider;
 import team.compass.common.utils.ResponseUtils;
 import team.compass.post.controller.request.PostRequest;
 import team.compass.post.controller.response.PostResponse;
@@ -16,9 +18,11 @@ import team.compass.theme.domain.Theme;
 import team.compass.user.domain.User;
 import team.compass.user.repository.UserRepository;
 
+import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@CrossOrigin(origins = "*")
 @RestController
 @RequiredArgsConstructor
 public class PostController {
@@ -27,6 +31,8 @@ public class PostController {
 
     private final UserRepository userRepository;
 
+    private final JwtTokenProvider jwtTokenProvider;
+
 
     @ApiOperation(value = "해당 테마 페이지 글들 select 입니다.", notes = "테마 페이지 select")
     @GetMapping("/post")
@@ -34,10 +40,6 @@ public class PostController {
     public ResponseEntity<Object> getThemePage(
             @RequestParam(required = false) Integer lastId, // required default 값이 true... 첫 상단에는 null이어야 하니 false 로 잡음
             @RequestParam(defaultValue = "1") Integer themeId) {
-        // 아무데이터도 안들어왔을때
-        // 기본값으로 theme 1 로 들어감 last id = null
-//        return  ResponseEntity.ok(postService.themePageSelect(themeId, lastId));
-
         if (themeId > 10) {
             return ResponseUtils.notFound("테마 글 리스트를 찾을 수 없습니다.");
         }
@@ -56,19 +58,19 @@ public class PostController {
     @Transactional
     public ResponseEntity<Object> postWrite(
             @RequestPart(value = "data") PostRequest postRequest, // request post 로 받아오기. 내용들
-            @RequestPart(value = "images") List<MultipartFile> images) { // 이미지 받아오기
-        validationPhoto(images); // 유효성 검증(이미지 최대 5개까지 받아올 수 있게)
-        User user = userRepository.findById(1)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // 임시로 넣어둔 유저
+            @RequestPart(value = "images") List<MultipartFile> images,
+            HttpServletRequest request) { // 이미지 받아오기
+        User user = getUser(request);
 
-        Post postEntity = getPostEntity(postRequest); // toEntity -> 넣어주기 ( 📌이 부분 고칠것)
+        validationPhoto(images); // 유효성 검증(이미지 최대 5개까지 받아올 수 있게)
+
+        Post postEntity = getPostEntity(postRequest); // toEntity -> 넣어주기 ( 📌이 부분 고칠것 - o)
         postEntity.setUser(user); // toEntity 에 user 값 넣기
 
         Post write = postService.write(postEntity, images, user); // 받았던 글 post(글과 사진, 유저) write 에 담기
 
-//        return ResponseEntity.ok(write);
         if (write != null) {
-            return ResponseUtils.ok("글을 작성하였습니다.", write);
+            return ResponseUtils.ok("글을 작성하였습니다.", "ok");
         } else {
             return ResponseUtils.notFound("글 작성에 실패하였습니다.");
         }
@@ -80,15 +82,12 @@ public class PostController {
     public ResponseEntity<Object> postUpdate(
             @RequestPart(value = "data") PostRequest postRequest,
             @RequestPart(value = "images") List<MultipartFile> images,
-            @PathVariable Integer postId) { // 글 id 받기 위해
+            @PathVariable Integer postId,
+            HttpServletRequest request) { // 글 id 받기 위해
 
+        User user = getUser(request);
         validationPhoto(images);
-        User user = userRepository.findById(1)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // user 체크
-
         Post updatePost = postService.update(getPostEntity(postRequest), images, user, postId); // 업데이트 받아온 것 저장
-
-//        return ResponseEntity.ok(new PostResponse(updatePost)); // response 에 담아 보내기
 
         if (updatePost != null) {
             return ResponseUtils.ok("글을 수정하였습니다.", new PostResponse(updatePost));
@@ -100,12 +99,9 @@ public class PostController {
     @ApiOperation(value = "글 삭제 api 입니다.", notes = "해당 글을 삭제하면 연관되어 있는 해당 글, 사진, 좋아요, 댓글 삭제됩니다.")
     @DeleteMapping(value = "/post/{postId}")
     @Transactional
-    public ResponseEntity<Object> postDelete(@PathVariable Integer postId) {
-        User user = userRepository.findById(1)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다.")); // user 체크
-//        postService.delete(postId);
-//        return ResponseEntity.ok("삭제되었습니다.");
-        boolean isDeleted = postService.delete(postId);
+    public ResponseEntity<Object> postDelete(@PathVariable Integer postId,HttpServletRequest request) {
+        User user = getUser(request);
+        boolean isDeleted = postService.delete(postId,user);
         if (isDeleted) {
             return ResponseUtils.ok("글을 삭제하였습니다.", null);
         } else {
@@ -127,8 +123,16 @@ public class PostController {
     }
 
 
-    // 사진 5개 등록 제한걸어두기
+    private User getUser(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        String userEmail =  authentication.getName();
+        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+        return user;
+    }
 
+
+    // 사진 5개 등록 제한걸어두기
     private static void validationPhoto(List<MultipartFile> images) {
         if (images.size() > 5) {
             throw new IllegalArgumentException("사진은 5장까지만 등록 가능합니다.");

--- a/src/main/java/team/compass/post/controller/response/PostResponse.java
+++ b/src/main/java/team/compass/post/controller/response/PostResponse.java
@@ -30,10 +30,13 @@ public class PostResponse {
     private List<String> storeFileUrl;
     private Integer likeCount;
 
+    private Integer themeId;
+
     private Long commentCount;
     private String nickname;
 
-    public PostResponse(Post post, Long aLong) {
+
+    public PostResponse(Post post, Long commentCount, Integer themeId) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.detail = post.getDetail();
@@ -44,7 +47,24 @@ public class PostResponse {
         this.endDate = post.getEndDate();
         this.storeFileUrl = post.getPhotos().stream().map(i->i.getPhoto().getStoreFileUrl()).collect(Collectors.toList());
         this.likeCount = post.getLikes().size();
-        this.commentCount=aLong;
+        this.commentCount=commentCount;
+        this.themeId = themeId;
+        this.nickname=post.getUser().getNickName();
+    }
+
+
+    public PostResponse(Post post, Long commentCount) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.detail = post.getDetail();
+        this.location = post.getLocation();
+        this.createdAt = post.getCreatedAt();
+        this.hashtag = post.getHashtag();
+        this.startDate = post.getStartDate();
+        this.endDate = post.getEndDate();
+        this.storeFileUrl = post.getPhotos().stream().map(i->i.getPhoto().getStoreFileUrl()).collect(Collectors.toList());
+        this.likeCount = post.getLikes().size();
+        this.commentCount=commentCount;
         this.nickname=post.getUser().getNickName();
     }
     public PostResponse(Post post) {

--- a/src/main/java/team/compass/post/dto/PostDto.java
+++ b/src/main/java/team/compass/post/dto/PostDto.java
@@ -14,7 +14,7 @@ public class PostDto {
     private Integer postId;
     private Integer likeCount;
 
-    private final String baseUrl = "https://compass-s3-bucket.s3.ap-northeast-2.amazonaws.com/"; // ±‚∫ª ¡÷º“ √ﬂ∞°
+    private final String baseUrl = "https://compass-s3-bucket.s3.ap-northeast-2.amazonaws.com/"; // Í∏∞Î≥∏ url
 
     private List<String> storeFileUrl;
 

--- a/src/main/java/team/compass/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/team/compass/post/repository/PostCustomRepositoryImpl.java
@@ -56,13 +56,13 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     public Optional<Post> findWithLikeById(@Param(value = "id") Integer id){
 
         EntityGraph<Post> entityGraph = entityManager.createEntityGraph(Post.class);
-        entityGraph.addAttributeNodes("photos","user");
+        entityGraph.addAttributeNodes("photos","user"); // photos(PostPhoto), user 참조
 
         Subgraph<Object> photos = entityGraph.addSubgraph("photos"); // 서브그래프 더해주기
-        photos.addAttributeNodes("photo");
+        photos.addAttributeNodes("photo"); // photo 참조
 
         Map<String,Object> hints = new HashMap<>();
-        hints.put("javax.persistence.fetchgraph", entityGraph);
+        hints.put("javax.persistence.fetchgraph", entityGraph); // 선택한 속성만 조회하기
         return Optional.ofNullable(entityManager.find(Post.class, id, hints));
     }
 }

--- a/src/main/java/team/compass/post/service/PostService.java
+++ b/src/main/java/team/compass/post/service/PostService.java
@@ -1,6 +1,7 @@
 package team.compass.post.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team.compass.post.controller.response.PostResponse;
 import team.compass.post.domain.Post;
@@ -19,7 +20,15 @@ public interface PostService {
 
 
 //    void delete(Integer postId);
-    boolean delete(Integer postId);
+
+    //    @Override
+//    @Transactional
+//    public void delete(Integer postId) {
+//        postRepository.deleteById(postId); // 삭제
+//    }
+
+    @Transactional
+    boolean delete(Integer postId, User user);
 
     PostResponse getPost(Integer postId);
 

--- a/src/main/java/team/compass/post/service/PostServiceImpl.java
+++ b/src/main/java/team/compass/post/service/PostServiceImpl.java
@@ -49,7 +49,7 @@ public class PostServiceImpl implements PostService {
 
     /**
      * 글 작성 (사진 포함 같이)
-     *
+     * <p>
      * 1. post 저장
      * 2. S3 로직 (사진 API), 사진 저장
      * 순서 : 글 -> 사진 -> postPhoto
@@ -73,17 +73,22 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public Post update(Post updatePost, List<MultipartFile> multipartFile, User user, Integer postId) {
         // post 업데이트
-        Post udPost = postRepository.findById(postId)
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
-        udPost.setTitle(updatePost.getTitle()); // 제목
-        udPost.setLocation(updatePost.getLocation()); // 장소
-        udPost.setDetail(updatePost.getDetail()); // 내용
-        // udPost.setCreatedAt(LocalDateTime.now());
-        // 수정일 -> 근데 등록일 기준으로 나중에 정렬하게 되면.. 이슈가 있을 수도?? 나중의 글 -> 새로 쓴 글로 바뀌어서.. -> pk 기준으로 정렬 상관없음
-        udPost.setStartDate(updatePost.getStartDate()); // 여행 시작
-        udPost.setEndDate(updatePost.getEndDate()); // 여행 끝
-        udPost.setHashtag(updatePost.getHashtag()); // 해시태그
-        udPost.setUser(user); // 나중에 Builder 로 다시 변경할것
+
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException(" 권한없음 ");
+        }
+
+        Post udPost = Post.builder()
+                .title(post.getTitle())
+                .location(post.getLocation())
+                .detail(post.getDetail())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
+                .hashtag(post.getHashtag())
+                .user(post.getUser())
+                .build();
 
         postRepository.save(udPost); // 업데이트로 쓰인 데이터들 repo 저장
         //사진 저장
@@ -102,15 +107,14 @@ public class PostServiceImpl implements PostService {
      * 함으로써 Post 삭제시 photos 도 삭제됨.
      * 처리 안 할 경우에 null 이 돼서 fk 가 보는 곳이 없어짐. 아니면 null 처리가 따로 있다던지..
      */
-//    @Override
-//    @Transactional
-//    public void delete(Integer postId) {
-//        postRepository.deleteById(postId); // 삭제
-//    }
-
     @Override
     @Transactional
-    public boolean delete(Integer postId) {
+    public boolean delete(Integer postId, User user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException(" 권한없음 ");
+        }
         postRepository.deleteById(postId); // 삭제
         return true;
     }
@@ -136,8 +140,9 @@ public class PostServiceImpl implements PostService {
     public PostResponse getPost(Integer postId) {
         Post post = postCustomRepository.findWithLikeById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+        Integer themeId = post.getTheme().getId();
         Long commentCount = commentRepository.countByPostId(postId);
-        return new PostResponse(post, commentCount);
+        return new PostResponse(post, commentCount, themeId);
     }
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/119172260/233571492-628de74f-c353-4d5b-a78d-013d300e1ca0.png)

기존에 있던 임시 User data를 지우고, 시큐리티 로그인 되어 있는 유저를 검증해 작성과 수정, 삭제를 가능케 합니다.

중복되는 로직이 많아 해당 로직을 메서드로 추출해 놓은 상태입니다.
![image](https://user-images.githubusercontent.com/119172260/233572121-70152bba-69ad-4d18-9e9b-bc937edab6bf.png)

수정 로직의 예시로, post의 getUser().getId()를 통해 post의 사용자 Id(email) user getId()를 비교하여 비교합니다.

![image](https://user-images.githubusercontent.com/119172260/233572934-436fa89b-8e93-4964-a71e-97fd23850030.png)
