### PR TITLE
Feature/post entity set

### DIFF
--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -90,7 +90,7 @@ public class PostController {
         Post updatePost = postService.update(getPostEntity(postRequest), images, user, postId); // 업데이트 받아온 것 저장
 
         if (updatePost != null) {
-            return ResponseUtils.ok("글을 수정하였습니다.", new PostResponse(updatePost));
+            return ResponseUtils.ok("글을 수정하였습니다.", "ok");//new PostResponse(updatePost)
         } else {
             return ResponseUtils.badRequest("글 수정에 실패하였습니다.");
         }

--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -127,7 +127,8 @@ public class PostController {
         String accessToken = jwtTokenProvider.resolveToken(request);
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         String userEmail =  authentication.getName();
-        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
         return user;
     }
 

--- a/src/main/java/team/compass/post/controller/response/PostResponse.java
+++ b/src/main/java/team/compass/post/controller/response/PostResponse.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import team.compass.post.domain.Post;
+import team.compass.user.domain.User;
 
 @Data
 @NoArgsConstructor
@@ -34,6 +35,7 @@ public class PostResponse {
 
     private Long commentCount;
     private String nickname;
+    private String userProfileImage;
 
 
     public PostResponse(Post post, Long commentCount, Integer themeId) {
@@ -49,7 +51,9 @@ public class PostResponse {
         this.likeCount = post.getLikes().size();
         this.commentCount=commentCount;
         this.themeId = themeId;
-        this.nickname=post.getUser().getNickName();
+        User user = post.getUser();
+        this.nickname= user.getNickName();
+        this.userProfileImage = user.getProfileImageUrl();
     }
 
 

--- a/src/main/java/team/compass/post/controller/response/PostResponse.java
+++ b/src/main/java/team/compass/post/controller/response/PostResponse.java
@@ -55,22 +55,6 @@ public class PostResponse {
         this.nickname= user.getNickName();
         this.userProfileImage = user.getProfileImageUrl();
     }
-
-
-    public PostResponse(Post post, Long commentCount) {
-        this.id = post.getId();
-        this.title = post.getTitle();
-        this.detail = post.getDetail();
-        this.location = post.getLocation();
-        this.createdAt = post.getCreatedAt();
-        this.hashtag = post.getHashtag();
-        this.startDate = post.getStartDate();
-        this.endDate = post.getEndDate();
-        this.storeFileUrl = post.getPhotos().stream().map(i->i.getPhoto().getStoreFileUrl()).collect(Collectors.toList());
-        this.likeCount = post.getLikes().size();
-        this.commentCount=commentCount;
-        this.nickname=post.getUser().getNickName();
-    }
     public PostResponse(Post post) {
         this.id = post.getId();
         this.title = post.getTitle();
@@ -82,7 +66,9 @@ public class PostResponse {
         this.endDate = post.getEndDate();
         this.storeFileUrl = post.getPhotos().stream().map(i->i.getPhoto().getStoreFileUrl()).collect(Collectors.toList());
         this.likeCount = post.getLikes().size();
-        this.nickname=post.getUser().getNickName();
+        User user = post.getUser();
+        this.nickname= user.getNickName();
+        this.userProfileImage = user.getProfileImageUrl();
     }
 
 

--- a/src/main/java/team/compass/post/service/PostServiceImpl.java
+++ b/src/main/java/team/compass/post/service/PostServiceImpl.java
@@ -23,6 +23,7 @@ import team.compass.user.domain.User;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -73,22 +74,29 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public Post update(Post updatePost, List<MultipartFile> multipartFile, User user, Integer postId) {
         // post 업데이트
-        Post post = postRepository.findById(postId)
+        Post udPost = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
 
-        if (!post.getUser().getId().equals(user.getId())) {
+        if (!udPost.getUser().getId().equals(user.getId())) {
             throw new IllegalArgumentException(" 권한없음 ");
         }
 
-        Post udPost = Post.builder()
-                .title(post.getTitle())
-                .location(post.getLocation())
-                .detail(post.getDetail())
-                .startDate(post.getStartDate())
-                .endDate(post.getEndDate())
-                .hashtag(post.getHashtag())
-                .user(post.getUser())
-                .build();
+//        Post udPost = Post.builder()
+//                .title(post.getTitle())
+//                .location(post.getLocation())
+//                .detail(post.getDetail())
+//                .startDate(post.getStartDate())
+//                .endDate(post.getEndDate())
+//                .hashtag(post.getHashtag())
+//                .user(post.getUser())
+//                .build();
+        udPost.setTitle(updatePost.getTitle()); // 제목
+        udPost.setLocation(updatePost.getLocation()); // 장소
+        udPost.setDetail(updatePost.getDetail()); // 내용
+        udPost.setStartDate(updatePost.getStartDate()); // 여행 시작
+        udPost.setEndDate(updatePost.getEndDate()); // 여행 끝
+        udPost.setHashtag(updatePost.getHashtag()); // 해시태그
+        udPost.setUser(user);
 
         postRepository.save(udPost); // 업데이트로 쓰인 데이터들 repo 저장
         //사진 저장

--- a/src/main/java/team/compass/user/domain/User.java
+++ b/src/main/java/team/compass/user/domain/User.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import team.compass.post.domain.Post;
 import team.compass.user.dto.UserRequest;
 
 import javax.persistence.*;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class User implements UserDetails {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false,name = "user_id")
     private Integer id;
 
@@ -52,8 +53,8 @@ public class User implements UserDetails {
 
 
     // post entity
-    // @OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
-    // private List<Post> posts;
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<Post> posts;
 
 
     @Override


### PR DESCRIPTION
* PostService 단에서 수정 부분이 entities must not be null! 오류가 발생하는 이슈가 있었습니다.


Builder 부분이 해당 오류를 발생하게 한 이유였습니다.

기존에 Builder 패턴에 있던 udPost.setUser(post.getUser()); 로직에서 null 문제가 있었는데, 이는 
객체의 값을 복사해 가져오려 하는데 proxy 기능으로 인해 user 객체가 LAZY 속성으로 지정되어 있어서 사용할 수 없는 상태입니다.

그래서 기존에 있던 Builder 패턴을 이용해 넣어주었던 형식을 Setter를 이용하여 변경하였습니다.  그렇다면 LAZY 속성이 아닌, EAGER 속성으로 변경했을 때는 결과값이 다를까 하여 실행해보았지만, 똑같은 결과였습니다.
게다가 EAGER 속성으로 지정해둘 시에 다른 post API에서도 EAGER 속성으로 인해 쿼리가 추가로 나갈 수 있음에 단점이 있습니다.

따라서 기존에 있던 LAZY 속성으로 지정하고 Setter로 넣어주는 방식을 선택하였습니다.

