### PR TITLE
Feat: 메일 전송 기능, 비밀번호 초기화 기능 수정, Refactor: 회원 서비스 로직 공통 코드 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	implementation group: 'com.mailjet', name: 'mailjet-client', version: '4.2.0'
+
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/team/compass/common/utils/MailUtils.java
+++ b/src/main/java/team/compass/common/utils/MailUtils.java
@@ -1,0 +1,65 @@
+package team.compass.common.utils;
+
+import com.mailjet.client.ClientOptions;
+import com.mailjet.client.MailjetClient;
+import com.mailjet.client.MailjetRequest;
+import com.mailjet.client.MailjetResponse;
+import com.mailjet.client.errors.MailjetException;
+import com.mailjet.client.errors.MailjetSocketTimeoutException;
+import com.mailjet.client.resource.Emailv31;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import team.compass.user.domain.User;
+
+@Component
+@RequiredArgsConstructor
+public class MailUtils {
+    @Value("${spring.mail.username}")
+    private String from;
+    @Value("${spring.mail.mailjet.api-key}")
+    private String apiKey;
+    @Value("${spring.mail.mailjet.secret-key}")
+    private String secretKey;
+
+    private String SUBJECT = "비밀번호 초기화 안내메일 입니다.";
+
+
+    public void sendMessage(User user) {
+        MailjetClient client = new MailjetClient(apiKey, secretKey, new ClientOptions("v3.1"));
+        MailjetRequest request = new MailjetRequest(Emailv31.resource)
+                .property(Emailv31.MESSAGES, new JSONArray()
+                        .put(
+                                new JSONObject()
+                                        .put(
+                                                Emailv31.Message.FROM,
+                                                new JSONObject().put("Email", from)
+                                        )
+                                        .put(
+                                                Emailv31.Message.TO,
+                                                new JSONArray().put(new JSONObject().put("Email", user.getEmail()))
+                                        )
+                                        .put(Emailv31.Message.SUBJECT, SUBJECT)
+                                        .put(
+                                                Emailv31.Message.HTMLPART,
+                                                "<h2>안녕하세요." + user.getNickName() + "님!</h2>"
+                                                + "<p>비밀번호 초기화 코드입니다.<p>"
+                                                + "<p><" + user.getResetPasswordKey() + "></p>"
+                                        )
+                        )
+                );
+
+
+        try {
+            // trigger the API call
+            MailjetResponse response = client.post(request);
+            // Read the response data and status
+        } catch (MailjetSocketTimeoutException e) {
+            throw new RuntimeException(e);
+        } catch (MailjetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/team/compass/post/repository/PostRepository.java
+++ b/src/main/java/team/compass/post/repository/PostRepository.java
@@ -38,7 +38,7 @@ public interface PostRepository extends JpaRepository<Post,Integer> {
     Optional<Page<Post>> findAllByUser_Id(Integer id, Pageable pageable);
 
     // 해당 유저 좋아요 클릭한 글 조회
-    Optional<Page<Post>> findAllByUser_IdAndLikes(Integer id, Pageable pageable);
+//    Optional<Page<Post>> findAllByUser_IdAndLikes(Integer id, Pageable pageable);
 
 
     Optional<Page<Post>> findAllByLikes_User_Id(Integer id, Pageable pageable);

--- a/src/main/java/team/compass/user/controller/UserController.java
+++ b/src/main/java/team/compass/user/controller/UserController.java
@@ -2,6 +2,7 @@ package team.compass.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,22 +13,23 @@ import team.compass.user.dto.*;
 import team.compass.user.service.UserService;
 
 import javax.servlet.http.HttpServletRequest;
+import java.nio.file.attribute.UserPrincipal;
+import java.security.Principal;
 import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
 @RestController
+@CrossOrigin(origins = "*")
 public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(
             @RequestPart(name = "data") UserRequest.SignUp parameter,
-            @RequestPart(name = "files", required = false) MultipartFile[] multiFiles,
             HttpServletRequest request
             ) {
         MultipartHttpServletRequest multipartHttpServletRequest = (MultipartHttpServletRequest) request;
-
 
         User user = userService.signUp(parameter, multipartHttpServletRequest);
 
@@ -56,6 +58,7 @@ public class UserController {
             @RequestBody UserUpdate parameter,
             HttpServletRequest request
     ) {
+
         User user = userService.updateUser(parameter, request);
 
         if(ObjectUtils.isEmpty(user)) {
@@ -100,19 +103,18 @@ public class UserController {
 
     @PostMapping("/password/send")
     public ResponseEntity<?> resetPasswordSendMsg(
-            HttpServletRequest request
+            @RequestBody UserPasswordResetMailRequest parameter
     ) {
-        userService.resetPasswordSendMsg(request);
+        userService.resetPasswordSendMsg(parameter);
 
         return ResponseUtils.ok("회원 비밀번호 초기화 메일 전송에 성공하였습니다.", true);
     }
 
     @PostMapping("/password/reset")
     public ResponseEntity<?> resetPassword(
-            HttpServletRequest request,
             @RequestBody PasswordResetRequest parameter
     ) {
-        userService.resetPassword(request, parameter);
+        userService.resetPassword(parameter);
 
         return ResponseUtils.ok("회원 비밀번호 초기화에 성공하였습니다.", true);
     }

--- a/src/main/java/team/compass/user/controller/UserController.java
+++ b/src/main/java/team/compass/user/controller/UserController.java
@@ -22,11 +22,14 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(
-            @RequestPart(value = "data") UserRequest.SignUp parameter,
-            MultipartHttpServletRequest request
+            @RequestPart(name = "data") UserRequest.SignUp parameter,
+            @RequestPart(name = "files", required = false) MultipartFile[] multiFiles,
+            HttpServletRequest request
             ) {
-        Map<String, MultipartFile> multipartFileMap = request.getFileMap();
-        User user = userService.signUp(parameter, multipartFileMap);
+        MultipartHttpServletRequest multipartHttpServletRequest = (MultipartHttpServletRequest) request;
+
+
+        User user = userService.signUp(parameter, multipartHttpServletRequest);
 
         if(ObjectUtils.isEmpty(user)) {
             return ResponseUtils.badRequest("회원가입에 실패하였습니다.");
@@ -79,6 +82,20 @@ public class UserController {
     ){
         userService.withdraw(request);
         return ResponseUtils.ok("회원탈퇴를 완료하였습니다.", true);
+    }
+
+    @PutMapping("/password/update")
+    public ResponseEntity<?> updatePassword(
+            @RequestBody PasswordInitRequest parameter,
+            HttpServletRequest request
+    ) {
+        UserResponse response = userService.updatePassword(parameter, request);
+
+        if(!ObjectUtils.isEmpty(response)) {
+            return ResponseUtils.ok("패스워드 변경에 성공했습니다.", response);
+        } else {
+            return ResponseUtils.badRequest("패스워드 변경에 실패하였습니다.");
+        }
     }
 
 

--- a/src/main/java/team/compass/user/controller/UserController.java
+++ b/src/main/java/team/compass/user/controller/UserController.java
@@ -98,6 +98,25 @@ public class UserController {
         }
     }
 
+    @PostMapping("/password/send")
+    public ResponseEntity<?> resetPasswordSendMsg(
+            HttpServletRequest request
+    ) {
+        userService.resetPasswordSendMsg(request);
+
+        return ResponseUtils.ok("회원 비밀번호 초기화 메일 전송에 성공하였습니다.", true);
+    }
+
+    @PostMapping("/password/reset")
+    public ResponseEntity<?> resetPassword(
+            HttpServletRequest request,
+            @RequestBody PasswordResetRequest parameter
+    ) {
+        userService.resetPassword(request, parameter);
+
+        return ResponseUtils.ok("회원 비밀번호 초기화에 성공하였습니다.", true);
+    }
+
 
     @GetMapping("/post/{type}")
     public ResponseEntity<?> getByUserPostList(
@@ -112,8 +131,6 @@ public class UserController {
 
         return ResponseUtils.ok("회원 좋아요 글 목록 조회에 성공했습니다.", response);
     }
-
-
 
 
     // 해당 유저 작성 글 조회

--- a/src/main/java/team/compass/user/domain/User.java
+++ b/src/main/java/team/compass/user/domain/User.java
@@ -56,7 +56,7 @@ public class User extends BaseEntity implements UserDetails {
 
     // 권한 추가?????
     @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> roles = new ArrayList<>();
+    private List<String> roles;
 
 
     @OneToMany(fetch = FetchType.LAZY)

--- a/src/main/java/team/compass/user/domain/User.java
+++ b/src/main/java/team/compass/user/domain/User.java
@@ -1,10 +1,7 @@
 package team.compass.user.domain;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.security.core.GrantedAuthority;
@@ -23,6 +20,7 @@ import java.util.stream.Collectors;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/team/compass/user/dto/PasswordInitRequest.java
+++ b/src/main/java/team/compass/user/dto/PasswordInitRequest.java
@@ -1,0 +1,19 @@
+package team.compass.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordInitRequest {
+    @NotEmpty(message = "기존 패스워드 입력은 필수입니다.")
+    String password;
+    @NotEmpty(message = "새로운 패스워드 입력은 필수입니다.")
+    String newPassword;
+}

--- a/src/main/java/team/compass/user/dto/PasswordResetRequest.java
+++ b/src/main/java/team/compass/user/dto/PasswordResetRequest.java
@@ -12,6 +12,8 @@ import javax.validation.constraints.NotEmpty;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PasswordResetRequest {
+    @NotEmpty(message = "이메일 값은 필수입니다.")
+    String email;
     @NotEmpty(message = "패스워드 입력은 필수입니다.")
     String password;
     @NotEmpty(message = "초기화 코드 입력은 필수입니다.")

--- a/src/main/java/team/compass/user/dto/PasswordResetRequest.java
+++ b/src/main/java/team/compass/user/dto/PasswordResetRequest.java
@@ -1,0 +1,19 @@
+package team.compass.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequest {
+    @NotEmpty(message = "패스워드 입력은 필수입니다.")
+    String password;
+    @NotEmpty(message = "초기화 코드 입력은 필수입니다.")
+    String uuid;
+}

--- a/src/main/java/team/compass/user/dto/UserPasswordResetMailRequest.java
+++ b/src/main/java/team/compass/user/dto/UserPasswordResetMailRequest.java
@@ -1,0 +1,17 @@
+package team.compass.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPasswordResetMailRequest {
+    @NotEmpty(message = "이메일 입력은 필수입니다.")
+    private String email;
+}

--- a/src/main/java/team/compass/user/service/UserService.java
+++ b/src/main/java/team/compass/user/service/UserService.java
@@ -21,9 +21,9 @@ public interface UserService {
 
     UserResponse updatePassword(PasswordInitRequest parameter, HttpServletRequest request);
 
-    void resetPasswordSendMsg(HttpServletRequest request);
+    void resetPasswordSendMsg(UserPasswordResetMailRequest parameter);
 
-    void resetPassword(HttpServletRequest request, PasswordResetRequest parameter);
+    void resetPassword(PasswordResetRequest parameter);
 
 
     UserPostResponse getUserByPost(HttpServletRequest request);

--- a/src/main/java/team/compass/user/service/UserService.java
+++ b/src/main/java/team/compass/user/service/UserService.java
@@ -21,6 +21,10 @@ public interface UserService {
 
     UserResponse updatePassword(PasswordInitRequest parameter, HttpServletRequest request);
 
+    void resetPasswordSendMsg(HttpServletRequest request);
+
+    void resetPassword(HttpServletRequest request, PasswordResetRequest parameter);
+
 
     UserPostResponse getUserByPost(HttpServletRequest request);
 

--- a/src/main/java/team/compass/user/service/UserService.java
+++ b/src/main/java/team/compass/user/service/UserService.java
@@ -2,23 +2,24 @@ package team.compass.user.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
 import team.compass.user.domain.User;
-import team.compass.user.dto.TokenDto;
-import team.compass.user.dto.UserPostResponse;
-import team.compass.user.dto.UserRequest;
-import team.compass.user.dto.UserUpdate;
+import team.compass.user.dto.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 @Service
 public interface UserService {
-    User signUp(UserRequest.SignUp parameter, Map<String, MultipartFile> multipartFileMap);
-    TokenDto signIn(UserRequest.SignIn parameter);
+//    User signUp(UserRequest.SignUp parameter, Map<String, MultipartFile> multipartFileMap);
+    User signUp(UserRequest.SignUp parameter, MultipartHttpServletRequest request);
+    UserResponse signIn(UserRequest.SignIn parameter);
 
     User updateUser(UserUpdate parameter, HttpServletRequest request);
     void logout(HttpServletRequest request);
     void withdraw(HttpServletRequest request);
+
+    UserResponse updatePassword(PasswordInitRequest parameter, HttpServletRequest request);
 
 
     UserPostResponse getUserByPost(HttpServletRequest request);

--- a/src/main/java/team/compass/user/service/UserServiceImpl.java
+++ b/src/main/java/team/compass/user/service/UserServiceImpl.java
@@ -25,6 +25,7 @@ import team.compass.user.repository.UserRepository;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -136,9 +137,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void resetPassword(HttpServletRequest request, PasswordResetRequest parameter) {
-        String accessToken = jwtTokenProvider.resolveToken(request);
-        User user = findUserByAccessToken(accessToken);
+    public void resetPassword(PasswordResetRequest parameter) {
+        User user = memberRepository.findByEmail(parameter.getEmail())
+                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
         if(!parameter.getUuid().equals(user.getResetPasswordKey()) ) {
             throw new RuntimeException("비밀번호 초기화 코드 오류입니다.");
@@ -151,11 +152,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void resetPasswordSendMsg(HttpServletRequest request) {
-        String accessToken = jwtTokenProvider.resolveToken(request);
-        String uuid = UUID.randomUUID().toString();
+    public void resetPasswordSendMsg(UserPasswordResetMailRequest parameter) {
+        User user = memberRepository.findByEmail(parameter.getEmail())
+                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
-        User user = findUserByAccessToken(accessToken);
+        String uuid = UUID.randomUUID().toString();
         user.setResetPasswordKey(uuid);
 
         memberRepository.save(user);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,8 @@ spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8080
 # batch size
 spring.jpa.properties.hibernate.default_batch_fetch_size= 50
+
+# mailjet
+spring.mail.username=
+spring.mail.mailjet.api-key=
+spring.mail.mailjet.secret-key=


### PR DESCRIPTION
### 1. Mailjet 연동

![스크린샷 2023-04-28 160119](https://user-images.githubusercontent.com/74961404/235077723-187b5799-9b7f-4903-8520-105501fa3eef.png)

- SUBJECT 변수 메일 제목 
- 메일 내용은 HTML 소스와 함께 해당 유저 닉네임과 초기화 코드를 담아 전달합니다.
- Mailjet api key가 필요하기에 properties 파일에 최하단 적용 후 테스트 부탁드립니다.

![스크린샷 2023-04-28 160455](https://user-images.githubusercontent.com/74961404/235078334-7790a861-6dc5-4dcc-a60a-f827acc05d98.png)

---

### 2. 회원 비밀번호 초기화 서비스 수정

AS-IS: 회원 로그인 된 상태에서 정보를 전달
TO-BE: 기존 회원 로그인 창에서 사용자가 비밀번호 정보를 알지 못하는 상황으로 수정

- 회원 이메일을 입력 받은 후 회원 이메일이 존재한다면 초기화 코드 메일 발송 (단순 user 이메일 값으로 해당 유저 존재 여부 판단) 전송과 동시에 초기화 코드는 db에 저장됩니다.

![스크린샷 2023-04-28 160840](https://user-images.githubusercontent.com/74961404/235078940-5c5ac8ac-ebe8-476b-81a7-2959c8995eb5.png)

- 메일 전송이 성공적으로 완료 후 초기화 코드와 새로운 비밀번호 입력
 -> 초기화 코드 validation
![스크린샷 2023-04-28 160959](https://user-images.githubusercontent.com/74961404/235079209-a4286620-8f13-4a4b-86c4-0327b426ae3a.png)


### 3. 유저 작성한 글 좋아요 한 글 페이징

- 페이징 처리 관련해서 현재는 첫번째 10개만 불러오도록 옵션값이 0으로 하드코딩 해둔상태입니다. 
- Pageable 에 page 옵션값을 1씩 올리는 방식으로 전달 받아 구현 할 예정입니다.
![스크린샷 2023-04-28 161430](https://user-images.githubusercontent.com/74961404/235080151-d63fa24b-a83e-47c7-82f9-c66f0a87c334.png)
- 말씀하신 10개 이후 조회가 필요하신 부분에 대해서는 프론트 분들과 상의해서 어떤방식으로 구현이 될지 방향을 잡고 request dto 수정과 함께 페이징 구현 완료하겠습니다.

![스크린샷 2023-04-28 161220](https://user-images.githubusercontent.com/74961404/235079680-916a71b7-050c-4e48-b8e4-331f21b6481d.png)






