### PR TITLE
Refactor : 글 수정 테마 오류, Post Repo 메서드 명, 쿼리 개선, User, UserPostResponse…

### DIFF
--- a/src/main/java/team/compass/post/controller/PostController.java
+++ b/src/main/java/team/compass/post/controller/PostController.java
@@ -90,7 +90,7 @@ public class PostController {
         Post updatePost = postService.update(getPostEntity(postRequest), images, user, postId); // 업데이트 받아온 것 저장
 
         if (updatePost != null) {
-            return ResponseUtils.ok("글을 수정하였습니다.", "ok");//new PostResponse(updatePost)
+            return ResponseUtils.ok("글을 수정하였습니다.", new PostResponse(updatePost));//new PostResponse(updatePost)
         } else {
             return ResponseUtils.badRequest("글 수정에 실패하였습니다.");
         }

--- a/src/main/java/team/compass/post/controller/response/PostResponse.java
+++ b/src/main/java/team/compass/post/controller/response/PostResponse.java
@@ -66,6 +66,8 @@ public class PostResponse {
         this.endDate = post.getEndDate();
         this.storeFileUrl = post.getPhotos().stream().map(i->i.getPhoto().getStoreFileUrl()).collect(Collectors.toList());
         this.likeCount = post.getLikes().size();
+        this.commentCount = (long) post.getContents().size();
+        this.themeId = post.getTheme().getId();
         User user = post.getUser();
         this.nickname= user.getNickName();
         this.userProfileImage = user.getProfileImageUrl();

--- a/src/main/java/team/compass/post/repository/PostRepository.java
+++ b/src/main/java/team/compass/post/repository/PostRepository.java
@@ -35,13 +35,26 @@ public interface PostRepository extends JpaRepository<Post,Integer> {
 
 
     // 해당 유저 작성 글 조회
-    Optional<Page<Post>> findAllByUser_Id(Integer id, Pageable pageable);
+    Optional<Page<Post>> findAllByUserId(Integer user_id, Pageable pageable);
 
-    // 해당 유저 좋아요 클릭한 글 조회
-//    Optional<Page<Post>> findAllByUser_IdAndLikes(Integer id, Pageable pageable);
+    // 내가 누른 좋아요 클릭한 글 조회
+    @Query("select l.post from Likes l left join l.post where l.user.id = :user_id")
+    Optional<Page<Post>> findAllByUserIdAndLikes(@Param ("user_id")Integer user_id,Pageable pageable);
 
 
-    Optional<Page<Post>> findAllByLikes_User_Id(Integer id, Pageable pageable);
+
+    Optional<Page<Post>> findAllByLikesUserId(Integer user_id, Pageable pageable);
 
 }
+
+
+//    // 해당 유저 작성 글 조회
+//    Optional<Page<Post>> findAllByUser_Id(Integer id, Pageable pageable);
+//
+//    // 해당 유저 좋아요 클릭한 글 조회
+////    Optional<Page<Post>> findAllByUser_IdAndLikes(Integer id, Pageable pageable);
+//
+//
+//    Optional<Page<Post>> findAllByLikes_User_Id(Integer id, Pageable pageable);
+
 

--- a/src/main/java/team/compass/post/service/PostService.java
+++ b/src/main/java/team/compass/post/service/PostService.java
@@ -20,13 +20,6 @@ public interface PostService {
     Post update(Post param, List<MultipartFile> multipartFile, User user, Integer postId);
 
 
-//    void delete(Integer postId);
-
-    //    @Override
-//    @Transactional
-//    public void delete(Integer postId) {
-//        postRepository.deleteById(postId); // 삭제
-//    }
 
     @Transactional
     boolean delete(Integer postId, User user);

--- a/src/main/java/team/compass/post/service/PostServiceImpl.java
+++ b/src/main/java/team/compass/post/service/PostServiceImpl.java
@@ -94,22 +94,13 @@ public class PostServiceImpl implements PostService {
         if (!udPost.getUser().getId().equals(user.getId())) {
             throw new IllegalArgumentException(" 권한없음 ");
         }
-
-//        Post udPost = Post.builder()
-//                .title(post.getTitle())
-//                .location(post.getLocation())
-//                .detail(post.getDetail())
-//                .startDate(post.getStartDate())
-//                .endDate(post.getEndDate())
-//                .hashtag(post.getHashtag())
-//                .user(post.getUser())
-//                .build();
         udPost.setTitle(updatePost.getTitle()); // 제목
         udPost.setLocation(updatePost.getLocation()); // 장소
         udPost.setDetail(updatePost.getDetail()); // 내용
         udPost.setStartDate(updatePost.getStartDate()); // 여행 시작
         udPost.setEndDate(updatePost.getEndDate()); // 여행 끝
         udPost.setHashtag(updatePost.getHashtag()); // 해시태그
+        udPost.setTheme(updatePost.getTheme()); //
         udPost.setUser(user);
 
         postRepository.save(udPost); // 업데이트로 쓰인 데이터들 repo 저장
@@ -196,21 +187,6 @@ public class PostServiceImpl implements PostService {
                 post.getLocation(),
                 post.getStartDate(),
                 post.getEndDate())).collect(Collectors.toList());
-//        for (Post post : postList) { // post 리스트를 postDto list 에 더해준다.
-//            result.add(new PostDto(
-//                    post.getId(),
-//                    // like
-//                    post.getLikes().size(),
-//                    // photo list 형식이니 stream
-//                    post.getPhotos().stream().map(i -> i.getPhoto().getStoreFileUrl()).collect(Collectors.toList()),
-//                    post.getTitle(),
-//                    post.getLocation(),
-//                    post.getStartDate(),
-//                    post.getEndDate())
-//            );
-//        }
-//        List<PostDto> postResult = result; // 그 담아진 결과 5개를 다시 담아서 리턴
-//        return postResult;
     }
 
 
@@ -225,8 +201,8 @@ public class PostServiceImpl implements PostService {
         User user = userRepository.findByEmail(authentication.getName())
                 .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
-        Page post = postRepository.findAllByLikes_User_Id(user.getId(), pageable)
-                .orElseThrow(() -> new RuntimeException("해당 글이 없습니다."));
+//        Page post = postRepository.findAllByLikesUserId(user.getId(), pageable)
+//                .orElseThrow(() -> new RuntimeException("해당 글이 없습니다."));
 
         return null;
     }

--- a/src/main/java/team/compass/user/domain/User.java
+++ b/src/main/java/team/compass/user/domain/User.java
@@ -3,14 +3,19 @@ package team.compass.user.domain;
 
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import team.compass.post.domain.Post;
+
 import team.compass.like.domain.Likes;
 import team.compass.post.domain.Post;
 import team.compass.user.dto.UserRequest;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;

--- a/src/main/java/team/compass/user/dto/UserPostResponse.java
+++ b/src/main/java/team/compass/user/dto/UserPostResponse.java
@@ -29,6 +29,8 @@ public class UserPostResponse {
                                 .hashtag(item.getHashtag())
                                 .location(item.getLocation())
                                 .createdAt(item.getCreatedAt())
+                                    .commentCount((long) item.getContents().size())
+                                    .likeCount(item.getLikes().size())
                                 .build()
                         ).collect(Collectors.toList())
                 )


### PR DESCRIPTION
# 글 수정 테마 오류, Post Repo 메서드 명, 쿼리 개선, User, UserPostResponse…

## 글 수정 테마 오류

먼저 글 수정부분에 있어서 테마가 들어가지 않아 수정하였습니다. 

## PostRepository 메서드(쿼리)

PostRepository 부분에서 스네이크 표기법으로 인해 오류가 있었습니다. 따라서 카멜 표기법으로 변경하였습니다.

![image](https://user-images.githubusercontent.com/119172260/235210622-35a33d5e-f8ee-48eb-908b-d5fdaddb4bb5.png)

Likes 부분에서...

`expects at least 2 arguments but only found 1. this leaves an operator of type simple_property for property likes unbound.`

해당 오류는 이렇습니다. JPA repository에서 해당 메서드 사용 시 엔티티에 없는 parameter를 사용해서 해당 오류가 발생합니다. 따라서 쿼리작성으로 변경해주었습니다.

## USER

Response로 내려줄 때, 목록 조회에서 좋아요, 댓글 카운트를 보기 위함으로 추가하였습니다.

![image](https://user-images.githubusercontent.com/119172260/235212032-408d21dd-d02c-49a6-856f-3bc7974077ae.png)

PostRepository에서 메서드 명을 변경함에 따라 service단에서도 변경하였습니다. **추가적으로 user service단에서 주석처리된 것이 있는데, merge 받으실 때 꼭 확인해 주시기 바랍니다.** 
