### PR TITLE
fix: 해당 회원 좋아요 표시글 / 작성한 글 수정

### DIFF
--- a/src/main/java/team/compass/common/utils/MailUtils.java
+++ b/src/main/java/team/compass/common/utils/MailUtils.java
@@ -45,8 +45,8 @@ public class MailUtils {
                                         .put(
                                                 Emailv31.Message.HTMLPART,
                                                 "<h2>안녕하세요." + user.getNickName() + "님!</h2>"
+                                                + "<p>" + user.getResetPasswordKey() + "</p>"
                                                 + "<p>비밀번호 초기화 코드입니다.<p>"
-                                                + "<p><" + user.getResetPasswordKey() + "></p>"
                                         )
                         )
                 );
@@ -63,3 +63,4 @@ public class MailUtils {
         }
     }
 }
+

--- a/src/main/java/team/compass/post/repository/PostRepository.java
+++ b/src/main/java/team/compass/post/repository/PostRepository.java
@@ -38,10 +38,8 @@ public interface PostRepository extends JpaRepository<Post,Integer> {
     Optional<Page<Post>> findAllByUser_Id(Integer id, Pageable pageable);
 
     // 해당 유저 좋아요 클릭한 글 조회
-//    Optional<Page<Post>> findAllByUser_IdAndLikes(Integer id, Pageable pageable);
-
-
-    Optional<Page<Post>> findAllByLikes_User_Id(Integer id, Pageable pageable);
+    @Query("select l.post from Likes l left join l.post where l.user.id = :user_id")
+    Optional<Page<Post>> findAllByUserIdAndLikes(@Param("user_id") Integer id, Pageable pageable);
 
 }
 

--- a/src/main/java/team/compass/post/service/PostService.java
+++ b/src/main/java/team/compass/post/service/PostService.java
@@ -1,5 +1,6 @@
 package team.compass.post.service;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,8 +34,6 @@ public interface PostService {
 
     PostResponse getPost(Integer postId);
 
-
-    Post getUserByLikePost(HttpServletRequest request);
 
     List<PostDto> themePageSelect(Integer themeId, Integer lastId);
 }

--- a/src/main/java/team/compass/post/service/PostServiceImpl.java
+++ b/src/main/java/team/compass/post/service/PostServiceImpl.java
@@ -24,14 +24,12 @@ import team.compass.post.repository.PostCustomRepository;
 import team.compass.post.repository.PostRepository;
 import team.compass.theme.domain.Theme;
 import team.compass.theme.repository.ThemeRepository;
-import team.compass.user.domain.RefreshToken;
 import team.compass.user.domain.User;
 import team.compass.user.repository.UserRepository;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -213,21 +211,4 @@ public class PostServiceImpl implements PostService {
 //        return postResult;
     }
 
-
-    @Override
-    public Post getUserByLikePost(HttpServletRequest request) {
-        Pageable pageable = PageRequest.of(0, 10);
-
-        String accessToken = jwtTokenProvider.resolveToken(request);
-
-        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-
-        User user = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
-
-        Page post = postRepository.findAllByLikes_User_Id(user.getId(), pageable)
-                .orElseThrow(() -> new RuntimeException("해당 글이 없습니다."));
-
-        return null;
-    }
 }

--- a/src/main/java/team/compass/user/controller/UserController.java
+++ b/src/main/java/team/compass/user/controller/UserController.java
@@ -123,33 +123,12 @@ public class UserController {
     @GetMapping("/post/{type}")
     public ResponseEntity<?> getByUserPostList(
             @PathVariable String type,
+            @RequestBody UserPostRequest parameter,
             HttpServletRequest request
     ) {
-        UserPostResponse response = null;
-
-        if(type.equals("like")){
-            response = userService.getUserByLikePost(request);
-        }
+        UserPostResponse response = userService.getUserByPost(request, type, parameter);
 
         return ResponseUtils.ok("회원 좋아요 글 목록 조회에 성공했습니다.", response);
     }
 
-
-    // 해당 유저 작성 글 조회
-    @GetMapping("/post")
-    public ResponseEntity<?> getUserByPost(HttpServletRequest request) {
-        UserPostResponse postResponse = userService.getUserByPost(request);
-
-        if(ObjectUtils.isEmpty(postResponse)) {
-            return ResponseUtils.badRequest("작성 게시글 조회에 실패했습니다.");
-        }
-        return ResponseUtils.ok("해당 유저가 작성한 게시글 조회에 성공했습니다.", postResponse);
-    }
-
-    @GetMapping("/like-post")
-    public ResponseEntity<?> getUserLikeByPost(HttpServletRequest request) {
-        UserPostResponse postResponse = userService.getUserByLikePost(request);
-
-        return ResponseUtils.ok("해당 유저가 좋아요한 게시글 조회에 성공했습니다.", postResponse);
-    }
 }

--- a/src/main/java/team/compass/user/dto/UserPostRequest.java
+++ b/src/main/java/team/compass/user/dto/UserPostRequest.java
@@ -1,0 +1,14 @@
+package team.compass.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPostRequest {
+    private Integer pageNum;
+}

--- a/src/main/java/team/compass/user/service/UserService.java
+++ b/src/main/java/team/compass/user/service/UserService.java
@@ -26,9 +26,8 @@ public interface UserService {
     void resetPassword(PasswordResetRequest parameter);
 
 
-    UserPostResponse getUserByPost(HttpServletRequest request);
+    UserPostResponse getUserByPost(HttpServletRequest request, String type, UserPostRequest parameter);
 
-    UserPostResponse getUserByLikePost(HttpServletRequest request);
 
     TokenDto reissue(TokenDto tokenRequestDto);
 }

--- a/src/main/java/team/compass/user/service/UserServiceImpl.java
+++ b/src/main/java/team/compass/user/service/UserServiceImpl.java
@@ -265,22 +265,16 @@ public class UserServiceImpl implements UserService {
 
 
     @Override
-    public UserPostResponse getUserByPost(HttpServletRequest request) {
-        Page<Post> postPage = getPostList(request);
+    public UserPostResponse getUserByPost(HttpServletRequest request, String type, UserPostRequest parameter) {
+        Page<Post> postPage = getPostList(request, type, parameter);
+
         return UserPostResponse.build(postPage);
     }
 
 
-    @Override
-    public UserPostResponse getUserByLikePost(HttpServletRequest request) {
-//        Page<Post> postPage = getLikePostList(request);
-//        return UserPostResponse.build(postPage);
-        return null;
-    }
-
-
-    private Page<Post> getPostList(HttpServletRequest request) {
-        Pageable pageable = PageRequest.of(0, 10);
+    private Page<Post> getPostList(HttpServletRequest request, String type, UserPostRequest parameter) {
+        Pageable pageable = PageRequest.of(parameter.getPageNum(), 10);
+        Page<Post> postPage = null;
 
         String accessToken = jwtTokenProvider.resolveToken(request);
 
@@ -290,26 +284,16 @@ public class UserServiceImpl implements UserService {
         User user = memberRepository.findByEmail(authentication.getName())
                 .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
-        Page<Post> postPage = postRepository.findAllByUser_Id(user.getId(), pageable)
-                .orElse(null);
+        if(type.equals("list")) {
+            postPage = postRepository.findAllByUser_Id(user.getId(), pageable)
+                    .orElse(null);
+        } else if(type.equals("like")) {
+            postPage = postRepository.findAllByUserIdAndLikes(user.getId(), pageable)
+                    .orElse(null);
+        }
 
         return postPage;
     }
-
-//    private Page<Post> getLikePostList(HttpServletRequest request) {
-//        Pageable pageable = PageRequest.of(0, 10);
-//
-//        String accessToken = jwtTokenProvider.resolveToken(request);
-//        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-//
-//        User user = memberRepository.findByEmail(authentication.getName())
-//                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
-//
-//        Page<Post> postPage = postRepository.findAllByUser_IdAndLikes(user.getId(), pageable)
-//                .orElse(null);
-//
-//        return postPage;
-//    }
 
 
     /**


### PR DESCRIPTION
### 마이페이지 해당 회원 좋아요 / 작성 글 리스트 수정
<img width="706" alt="스크린샷 2023-04-29 오전 10 12 58" src="https://user-images.githubusercontent.com/74961404/235275574-b0182b32-6393-4129-b4bc-eae0379d8720.png">

- 회원 좋아요 리스트 조회는 미구현 상태였으나 Query문 조언을 받아 반영하여 리스트 조회 성공적으로 테스트 했습니다.
- api url path type 에 따라 같은 메소드에서 해당 회원 작성 글 및 좋아요 표시글을 반환하도록  구현했습니다.

<img width="888" alt="스크린샷 2023-04-29 오전 10 49 23" src="https://user-images.githubusercontent.com/74961404/235278045-4cbd3c76-3c0d-4977-b676-6192fca71a8f.png">

- Page 로 반환, request body로 현재 페이지 정보를 받으면 다음 리스트를 출력합니다.
