### PR TITLE
Refactor : UserRequest 생성자, 좋아요 기능

### DIFF
--- a/src/main/java/team/compass/like/controller/LikeController.java
+++ b/src/main/java/team/compass/like/controller/LikeController.java
@@ -1,9 +1,19 @@
 package team.compass.like.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import team.compass.common.config.JwtTokenProvider;
+import team.compass.common.utils.ResponseUtils;
 import team.compass.like.dto.LikeDto;
 import team.compass.like.service.LikeService;
+import team.compass.user.domain.User;
+import team.compass.user.repository.UserRepository;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,8 +21,48 @@ public class LikeController {
 
     private final LikeService likeService;
 
-    @PostMapping("/post/like")
-    public void addLike(@RequestBody LikeDto likeDto, @PathVariable Integer id){
-        likeService.saveLike(likeDto);
+    private final UserRepository userRepository;
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+//    @PostMapping("/post/like")
+//    public void addLike(@RequestBody LikeDto likeDto, @PathVariable Integer id) {
+//        likeService.saveLike(likeDto);
+//    }
+
+    @Transactional
+    @PostMapping("/like/{postId}")
+    public ResponseEntity<Object> addLike(
+            HttpServletRequest request,
+            @PathVariable Integer postId) {
+        boolean result = false;
+        User user = getUser(request);
+        if (Objects.nonNull(user))
+            result = likeService.addLike(user, postId);
+
+        return result ?
+                ResponseUtils.ok("좋아요 등록 성공", "ok") : ResponseUtils.badRequest("좋아요 등록 실패");
+    }
+
+    @Transactional
+    @DeleteMapping("/like/{postId}")
+    public ResponseEntity<Object> cancelLike(
+            HttpServletRequest request,
+            @PathVariable Integer postId) {
+        User user = getUser(request);
+        if (user != null) {
+            likeService.cancelLikes(user, postId);
+        }
+        return ResponseUtils.ok("좋아요 취소 성공", "ok");
+    }
+
+
+    private User getUser(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        String userEmail = authentication.getName();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+        return user;
     }
 }

--- a/src/main/java/team/compass/like/repository/LikeRepository.java
+++ b/src/main/java/team/compass/like/repository/LikeRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.stereotype.Repository;
 import team.compass.like.domain.Likes;
+import team.compass.post.domain.Post;
+import team.compass.user.domain.User;
 
 
 import java.util.Optional;
@@ -13,4 +15,6 @@ public interface LikeRepository extends JpaRepository<Likes, Integer> {
 
     Optional<Likes> findAllByPost_IdAndUser_Id(Integer post_id,
                                                Integer user_id);
+
+    Optional<Likes> findByUserAndPost(User user, Post post);
 }

--- a/src/main/java/team/compass/like/service/LikeService.java
+++ b/src/main/java/team/compass/like/service/LikeService.java
@@ -44,4 +44,31 @@ public class LikeService {
 
         return state;
     }
+
+
+
+    public boolean addLike(User user, Integer postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("글 없음"));
+
+        if (isNotAlreadyLikes(user, post)) {
+            likeRepository.save(new Likes(post, user));
+            return true;
+        }
+        return false;
+    }
+
+    public void cancelLikes(User user, Integer postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("글 없음"));
+
+        Likes likes = likeRepository.findByUserAndPost(user, post)
+                .orElseThrow(() -> new IllegalArgumentException("사용자나 글 조회가 안 됨. 또는 사용자 권한이 없음."));
+
+        likeRepository.delete(likes);
+    }
+
+    private boolean isNotAlreadyLikes(User user, Post post) {
+        return likeRepository.findByUserAndPost(user, post).isEmpty();
+    }
 }

--- a/src/main/java/team/compass/user/dto/UserRequest.java
+++ b/src/main/java/team/compass/user/dto/UserRequest.java
@@ -1,8 +1,6 @@
 package team.compass.user.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import team.compass.user.domain.User;
 
 import javax.validation.constraints.NotEmpty;
@@ -11,6 +9,8 @@ public class UserRequest {
     @Getter
     @Setter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class SignIn {
         private String email;
         private String password;
@@ -19,6 +19,8 @@ public class UserRequest {
     @Getter
     @Setter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class SignUp {
         @NotEmpty(message = "이메일 입력은 필수입니다.")
         private String email;
@@ -46,6 +48,8 @@ public class UserRequest {
 
     @Getter
     @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Logout {
         private String email;
         private String accessToken;


### PR DESCRIPTION
# UserRequest 생성자, 좋아요 기능

### UserRequest 영역에서 생성자가 없어서 생기는 오류가 있었습니다.

`cannot construct instance of team.compass.user.dto.userrequestsignin (no creators, like default constructor, exist): cannot deserialize from object value (no delegate- or property-based creator)`

표기에는 sign-in만이 나와있지만, 다른 inner class에서도 해당 사항에 속해 있기에 생성자를 추가해줬습니다.

### 좋아요 기능
기존에는 body 형식으로 raw를 추가해 postId, userId를 직접 넣어줌과 동시에 header값에도 user token값이 들어가야 좋아요 등록이 되던 기능이었습니다.

사용자가 이미 좋아요를 누른 게시물인지 체크해 가며 Exception을 뿌려 주었습니다.